### PR TITLE
New ProfileForecaster object

### DIFF
--- a/Zero_engine.alp
+++ b/Zero_engine.alp
@@ -6492,9 +6492,9 @@ v_currentEnergyExport_kW = max(0,-v_totalElectricPower_kW) + max(0, -v_totalMeth
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
-					<Body><![CDATA[pf_windOnshoreProduction = new J_ProfileForecaster(pp_windOnshoreProduction, p_forecastTime_h, t_h, p_timeStep_h);
+					<Body><![CDATA[pf_windOnshoreProduction = new J_ProfileForecaster(null, pp_windOnshoreProduction, p_forecastTime_h, t_h, p_timeStep_h);
 c_forecasts.add(pf_windOnshoreProduction);
-pf_solarPVproduction = new J_ProfileForecaster(pp_solarPVproduction, p_forecastTime_h, t_h, p_timeStep_h);
+pf_solarPVproduction = new J_ProfileForecaster(null, pp_solarPVproduction, p_forecastTime_h, t_h, p_timeStep_h);
 c_forecasts.add(pf_solarPVproduction);
 
 /*
@@ -56368,7 +56368,8 @@ public class J_Address implements Serializable {
  * J_ProfileForecaster
  */	
 public class J_ProfileForecaster implements Serializable {
-
+	
+	private String name = "";
 	private J_ProfilePointer profilePointer;
 	private double forecastTime_h = 0;
 	private double timeStep_h = 0;
@@ -56377,7 +56378,13 @@ public class J_ProfileForecaster implements Serializable {
     /**
      * Default constructor
      */
-    public J_ProfileForecaster(J_ProfilePointer pp, double forecastTime_h, double currentTime_h, double timeStep_h) {
+    public J_ProfileForecaster(String forecastName, J_ProfilePointer pp, double forecastTime_h, double currentTime_h, double timeStep_h) {
+    	if (forecastName == null) {
+    		this.name = pp.name + " " + forecastTime_h + " h";
+    	}
+    	else {
+    		this.name = forecastName;
+    	}
     	this.profilePointer = pp;
     	this.forecastTime_h = forecastTime_h;
     	this.timeStep_h = timeStep_h;
@@ -56400,12 +56407,16 @@ public class J_ProfileForecaster implements Serializable {
     }
     
     public String getName() {
-    	return this.profilePointer.name;
+    	return this.name;
+    }
+    
+    public double getForecastTime_h() {
+    	return this.forecastTime_h;
     }
     
 	@Override
 	public String toString() {
-		return "profile: " + this.profilePointer.name + " current forecast: " + this.currentForecast;
+		return "forecast name: " + this.name + ", current forecast: " + this.currentForecast;
 	}
 
 	/**

--- a/Zero_engine.alp
+++ b/Zero_engine.alp
@@ -1433,7 +1433,7 @@ traceln("Available profiles in this simulation: %s", c_profiles);
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
-						<Type><![CDATA[J_profilePointer]]></Type>        
+						<Type><![CDATA[J_ProfilePointer]]></Type>        
 					</Properties>
 				</Variable>
 				<Variable Class="PlainVariable">
@@ -4630,7 +4630,7 @@ traceln("Available profiles in this simulation: %s", c_profiles);
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
-						<Type><![CDATA[J_profilePointer]]></Type>        
+						<Type><![CDATA[J_ProfilePointer]]></Type>        
 					</Properties>
 				</Variable>
 				<Variable Class="PlainVariable">
@@ -4644,6 +4644,30 @@ traceln("Available profiles in this simulation: %s", c_profiles);
 					<ShowLabel>true</ShowLabel>
 					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
 						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1727784890604</Id>
+					<Name><![CDATA[pf_windOnshoreProduction]]></Name>
+					<X>-670</X><Y>210</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[J_ProfileForecaster]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1727784892429</Id>
+					<Name><![CDATA[pf_solarPVproduction]]></Name>
+					<X>-670</X><Y>230</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[J_ProfileForecaster]]></Type>        
 					</Properties>
 				</Variable>
 				<Variable Class="Parameter">
@@ -5550,14 +5574,29 @@ traceln("Available profiles in this simulation: %s", c_profiles);
 				<Variable Class="CollectionVariable">
 					<Id>1727099354305</Id>
 					<Name><![CDATA[c_profiles]]></Name>
-					<X>-670</X><Y>220</Y>
+					<X>-670</X><Y>250</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Properties SaveInSnapshot="true" AccessType="default" StaticVariable="false">
 						<CollectionClass><![CDATA[ArrayList]]></CollectionClass>
-						<ElementClass><![CDATA[J_profilePointer]]></ElementClass>
+						<ElementClass><![CDATA[J_ProfilePointer]]></ElementClass>
+						<ValueElementClass><![CDATA[String]]></ValueElementClass>
+					</Properties>
+
+				</Variable>
+				<Variable Class="CollectionVariable">
+					<Id>1727779411251</Id>
+					<Name><![CDATA[c_forecasts]]></Name>
+					<X>-670</X><Y>270</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" AccessType="public" StaticVariable="false">
+						<CollectionClass><![CDATA[ArrayList]]></CollectionClass>
+						<ElementClass><![CDATA[J_ProfileForecaster]]></ElementClass>
 						<ValueElementClass><![CDATA[String]]></ValueElementClass>
 					</Properties>
 
@@ -6041,8 +6080,8 @@ for (GridNode GN : c_gridNodeExecutionListReverse) {
 					<Body><![CDATA[v_currentAmbientTemperature_degC = tf_ambientTemperature_degC(t_h);
 
 c_profiles.forEach(p -> p.updateValue(t_h));
-v_currentWindPowerNormalized_r = pp_windOnshoreProduction.getValue();
-v_currentSolarPowerNormalized_r = pp_solarPVproduction.getValue();
+v_currentWindPowerNormalized_r = pp_windOnshoreProduction.getCurrentValue();
+v_currentSolarPowerNormalized_r = pp_solarPVproduction.getCurrentValue();
 //v_currentCookingDemand_fr = tf_cooking_demand(t_h);
 
 if (b_enableDLR) {
@@ -6074,9 +6113,11 @@ for( J_EA e : c_ambientAirDependentAssets ) {
 	}
 }
 
-// Update weather forecast
-v_SolarYieldForecast_fr += (tf_p_solar_e_normalized(t_h+p_forecastTime_h)-v_currentSolarPowerNormalized_r)/(p_forecastTime_h/p_timeStep_h);
-v_WindYieldForecast_fr += (tf_p_wind_e_normalized(t_h+p_forecastTime_h)-v_currentWindPowerNormalized_r)/(p_forecastTime_h/p_timeStep_h);
+// Update forecasts,  the relevant profile pointers are already updated above
+c_forecasts.forEach(f -> f.updateForecast(t_h));
+v_SolarYieldForecast_fr = pf_solarPVproduction.getForecast();
+v_WindYieldForecast_fr = pf_windOnshoreProduction.getForecast();
+// The ElectricityYieldForecast assumes solar and wind forecasts have the same forecast time
 v_electricityYieldForecast_fr = (v_SolarYieldForecast_fr * v_totalInstalledPVPower_kW + v_WindYieldForecast_fr * v_totalInstalledWindPower_kW) / (v_totalInstalledPVPower_kW + v_totalInstalledWindPower_kW);
 
 for (GridNode GN : c_gridNodeExecutionList) {
@@ -6451,15 +6492,18 @@ v_currentEnergyExport_kW = max(0,-v_totalElectricPower_kW) + max(0, -v_totalMeth
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
-					<Body><![CDATA[v_WindYieldForecast_fr = 0;
-v_SolarYieldForecast_fr = 0;
+					<Body><![CDATA[pf_windOnshoreProduction = new J_ProfileForecaster(pp_windOnshoreProduction, p_forecastTime_h, t_h, p_timeStep_h);
+c_forecasts.add(pf_windOnshoreProduction);
+pf_solarPVproduction = new J_ProfileForecaster(pp_solarPVproduction, p_forecastTime_h, t_h, p_timeStep_h);
+c_forecasts.add(pf_solarPVproduction);
+
+/*
 v_epexForecast_eurpkWh = 0;
 for (double ts_h = t_h; ts_h<t_h+p_forecastTime_h; ts_h += p_timeStep_h) {
-	v_WindYieldForecast_fr += tf_p_wind_e_normalized(ts_h)/(p_forecastTime_h/p_timeStep_h);
-	v_SolarYieldForecast_fr += tf_p_solar_e_normalized(ts_h)/(p_forecastTime_h/p_timeStep_h);
 	//v_epexForecast_eurpkWh += nationalEnergyMarket.tf_dayAheadElectricityPricing_eurpMWh(ts_h)/(p_forecastTime_h/p_timeStep_h)/1000;
 }
-//v_epexForecast_eurpkWh += 0.17;]]></Body>
+//v_epexForecast_eurpkWh += 0.17;
+*/]]></Body>
 				</Function>
 				<Function AccessType="public" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
@@ -8283,7 +8327,7 @@ traceln("Finished writing trafoloads to excel!");]]></Body>
 					<ShowLabel>true</ShowLabel>
 					<Parameter>
 						<Name><![CDATA[profile]]></Name>
-						<Type><![CDATA[J_profilePointer]]></Type>
+						<Type><![CDATA[J_ProfilePointer]]></Type>
 					</Parameter>
 					<Body><![CDATA[c_profiles.add(profile);]]></Body>
 				</Function>
@@ -8301,7 +8345,7 @@ traceln("Finished writing trafoloads to excel!");]]></Body>
 				</Function>
 				<Function AccessType="public" StaticFunction="false">
 					<ReturnModificator>RETURNS_VALUE</ReturnModificator>
-					<ReturnType><![CDATA[J_profilePointer]]></ReturnType>
+					<ReturnType><![CDATA[J_ProfilePointer]]></ReturnType>
 					<Id>1727193246625</Id>
 					<Name><![CDATA[f_findProfile]]></Name>
 					<X>-670</X><Y>410</Y>
@@ -8313,7 +8357,7 @@ traceln("Finished writing trafoloads to excel!");]]></Body>
 						<Name><![CDATA[assetName]]></Name>
 						<Type><![CDATA[String]]></Type>
 					</Parameter>
-					<Body><![CDATA[J_profilePointer profilePointer = findFirst(c_profiles, p -> p.name.equals(assetName));
+					<Body><![CDATA[J_ProfilePointer profilePointer = findFirst(c_profiles, p -> p.name.equals(assetName));
 //traceln("J_EAConsumption with name %s found profile asset: %s", assetName, profilePointer);
 if (profilePointer == null) {    		
 	throw new RuntimeException(String.format("Consumption or production asset without valid profile!") );
@@ -16475,7 +16519,8 @@ if ( p_energyType == OL_EnergyCarrierType.HEAT ) {
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
-					<Body><![CDATA[v_electricityYieldForecast_fr = (energyModel.v_SolarYieldForecast_fr * v_totalInstalledPVPower_kW + energyModel.v_WindYieldForecast_fr * v_totalInstalledWindPower_kW) / (v_totalInstalledPVPower_kW + v_totalInstalledWindPower_kW);
+					<Body><![CDATA[// The ElectricityYieldForecast assumes solar and wind forecasts have the same forecast time
+v_electricityYieldForecast_fr = (energyModel.v_SolarYieldForecast_fr * v_totalInstalledPVPower_kW + energyModel.v_WindYieldForecast_fr * v_totalInstalledWindPower_kW) / (v_totalInstalledPVPower_kW + v_totalInstalledWindPower_kW);
 ]]></Body>
 				</Function>
 				<Function AccessType="default" StaticFunction="false">
@@ -51977,7 +52022,7 @@ if (j_ea instanceof J_EAVehicle) {
  * J_EAProduction
  */
 public class J_EAProduction extends zero_engine.J_EA implements Serializable {
-	protected J_profilePointer profilePointer;
+	protected J_ProfilePointer profilePointer;
 	//public double yearlyProductionElectricity_kWh;
 	//public double yearlyProductionHeat_kWh;
 	public double yearlyProductionHydrogen_kWh;
@@ -51993,7 +52038,7 @@ public class J_EAProduction extends zero_engine.J_EA implements Serializable {
 	/**
      * Constructor initializing the fields
      */
-	public J_EAProduction(Agent parentAgent, OL_EnergyAssetType type, String name, double capacityElectric_kW ,double capacityHeat_kW, double yearlyProductionMethane_kWh, double yearlyProductionHydrogen_kWh, double timestep_h, double outputTemperature_degC, J_profilePointer profile) {
+	public J_EAProduction(Agent parentAgent, OL_EnergyAssetType type, String name, double capacityElectric_kW ,double capacityHeat_kW, double yearlyProductionMethane_kWh, double yearlyProductionHydrogen_kWh, double timestep_h, double outputTemperature_degC, J_ProfilePointer profile) {
 	    this.parentAgent = parentAgent;
 	    this.energyAssetType = type;
 	    this.energyAssetName = name;
@@ -52044,7 +52089,7 @@ public class J_EAProduction extends zero_engine.J_EA implements Serializable {
 	@Override
     public double[] operate(double ratioOfCapacity) {
 		if (profilePointer != null) {			
-			ratioOfCapacity = profilePointer.getValue();
+			ratioOfCapacity = profilePointer.getCurrentValue();
 		}
 		
     	this.electricityProduction_kW = ratioOfCapacity * capacityElectric_kW;
@@ -52280,7 +52325,7 @@ public class J_EAConversion extends zero_engine.J_EA implements Serializable {
  * J_EAConsumption
  */
 public class J_EAConsumption extends zero_engine.J_EA implements Serializable {
-	protected J_profilePointer profilePointer;
+	protected J_ProfilePointer profilePointer;
 	public double yearlyDemandElectricity_kWh;
 	public double yearlyDemandHeat_kWh;
 	public double yearlyDemandHydrogen_kWh;
@@ -52298,7 +52343,7 @@ public class J_EAConsumption extends zero_engine.J_EA implements Serializable {
     /**
      * Constructor initializing the fields
      */
-    public J_EAConsumption(Agent parentAgent, OL_EnergyAssetType type, String name, double yearlyDemandElectricity_kWh, double yearlyDemandHeat_kWh, double yearlyDemandHydrogen_kWh, double yearlyDemandMethane_kWh, double yearlyDemandDiesel_kWh, double timestep_h, J_profilePointer profile) {
+    public J_EAConsumption(Agent parentAgent, OL_EnergyAssetType type, String name, double yearlyDemandElectricity_kWh, double yearlyDemandHeat_kWh, double yearlyDemandHydrogen_kWh, double yearlyDemandMethane_kWh, double yearlyDemandDiesel_kWh, double timestep_h, J_ProfilePointer profile) {
 		this.energyAssetName = name;
 		this.energyAssetType = type;
     	this.parentAgent = parentAgent;
@@ -52333,7 +52378,7 @@ public class J_EAConsumption extends zero_engine.J_EA implements Serializable {
     public double[] operate(double ratioOfCapacity) {
 		
 		if (profilePointer != null) {			
-			ratioOfCapacity = profilePointer.getValue();
+			ratioOfCapacity = profilePointer.getCurrentValue();
 		}
 		
     	this.electricityConsumption_kW = ratioOfCapacity * yearlyDemandElectricity_kWh*consumptionScaling_fr;
@@ -56317,36 +56362,95 @@ public class J_Address implements Serializable {
 		</JavaClass>
 		<!--   =========   Java Class   ========  -->
 		<JavaClass>
-			<Id>1727097730196</Id>
-			<Name><![CDATA[J_profilePointer]]></Name>
+			<Id>1727774738469</Id>
+			<Name><![CDATA[J_ProfileForecaster]]></Name>
 			<Text><![CDATA[/**
- * profilePointer
+ * J_ProfileForecaster
  */	
-public class J_profilePointer implements Serializable {
-	public String name = "";
-	private double currentValue = 0;
-	private TableFunction tableFunction;
+public class J_ProfileForecaster implements Serializable {
+
+	private J_ProfilePointer profilePointer;
+	private double forecastTime_h = 0;
+	private double timeStep_h = 0;
+	private double currentForecast = 0;
+	
     /**
      * Default constructor
      */
-    public J_profilePointer(String name, TableFunction tableFunction) {
+    public J_ProfileForecaster(J_ProfilePointer pp, double forecastTime_h, double currentTime_h, double timeStep_h) {
+    	this.profilePointer = pp;
+    	this.forecastTime_h = forecastTime_h;
+    	this.timeStep_h = timeStep_h;
+    	this.initializeForecast(currentTime_h);
+    }
+
+    private void initializeForecast(double currentTime_h) {
+    	this.currentForecast = 0;
+    	for (double t_h = currentTime_h; t_h < currentTime_h + this.forecastTime_h; t_h += this.timeStep_h) {
+    		this.currentForecast += this.profilePointer.getValue(t_h) / (this.forecastTime_h/this.timeStep_h);
+    	}
+    }
+    
+    public void updateForecast(double t_h) {
+    	this.currentForecast += (this.profilePointer.getValue(t_h + this.forecastTime_h) - this.profilePointer.getCurrentValue()) / (this.forecastTime_h/this.timeStep_h);
+    }
+    
+    public double getForecast() {
+    	return this.currentForecast;
+    }
+    
+    public String getName() {
+    	return this.profilePointer.name;
+    }
+    
+	@Override
+	public String toString() {
+		return "profile: " + this.profilePointer.name + " current forecast: " + this.currentForecast;
+	}
+
+	/**
+	 * This number is here for model snapshot storing purpose<br>
+	 * It needs to be changed when this class gets changed
+	 */ 
+	private static final long serialVersionUID = 1L;
+
+}]]></Text>
+		</JavaClass>
+		<!--   =========   Java Class   ========  -->
+		<JavaClass>
+			<Id>1727775512403</Id>
+			<Name><![CDATA[J_ProfilePointer]]></Name>
+			<Text><![CDATA[/**
+ * J_ProfilePointer
+ */	
+public class J_ProfilePointer implements Serializable {
+	public String name = "";
+	private double currentValue = 0;
+	private TableFunction tableFunction;
+	
+    /**
+     * Default constructor
+     */
+    public J_ProfilePointer(String name, TableFunction tableFunction) {
     	this.name = name;
     	this.tableFunction = tableFunction;
     }
 
     public void updateValue(double t_h) {
-    	currentValue = tableFunction.get(t_h);
+    	this.currentValue = this.tableFunction.get(t_h);
     }
     
-    public double getValue() {
-    	return currentValue;
+    public double getCurrentValue() {
+    	return this.currentValue;
+    }
+    
+    public double getValue(double t_h) {
+    	return this.tableFunction.get(t_h);
     }
     
 	@Override
 	public String toString() {
-		String returnString = "profile " + this.name + " current value: " + this.currentValue;
-		return returnString;
-		//return super.toString();
+		return "profile: " + this.name + " current value: " + this.currentValue; 
 	}
 
 	/**


### PR DESCRIPTION
- Contains a breaking change, namely J_profilePointer was changed to J_ProfilePointer and its method getValue() has been replaced with getCurrentValue() ( Although I believe this method is not generally used outside of the engine)
- The profile forecaster contains a reference to a profile pointer. It can be instantiated with different forecast times. The Solar and Wind forecasts are created by default and live on the energyModel canvas. Other forecaster objects should be created in the loader and can later be found by name (of the profile pointer)