### PR TITLE
GCNeighborhood, now also possible to use hydrogen as source for heating (for now COMPANIES ONLY) + conversion asset fixes

### DIFF
--- a/Zero_engine.alp
+++ b/Zero_engine.alp
@@ -10389,6 +10389,9 @@ dsm_liveSupply_kW.createEmptyDataSets(v_activeEnergyCarriers, (int) (168 / p_tim
 						<Parameter>
 							<Name><![CDATA[p_address]]></Name>
 						</Parameter>
+						<Parameter>
+							<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
+						</Parameter>
 					</Parameters>
 					<ReplicationFlag>true</ReplicationFlag>
 					<Replication Class="CodeValue">
@@ -11275,6 +11278,9 @@ dsm_liveSupply_kW.createEmptyDataSets(v_activeEnergyCarriers, (int) (168 / p_tim
 						<Parameter>
 							<Name><![CDATA[p_cookingMethod]]></Name>
 						</Parameter>
+						<Parameter>
+							<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
+						</Parameter>
 					</Parameters>
 					<ReplicationFlag>true</ReplicationFlag>
 					<Replication Class="CodeValue">
@@ -11437,6 +11443,9 @@ dsm_liveSupply_kW.createEmptyDataSets(v_activeEnergyCarriers, (int) (168 / p_tim
 						<Parameter>
 							<Name><![CDATA[p_address]]></Name>
 						</Parameter>
+						<Parameter>
+							<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
+						</Parameter>
 					</Parameters>
 					<ReplicationFlag>true</ReplicationFlag>
 					<Replication Class="CodeValue">
@@ -11595,6 +11604,9 @@ dsm_liveSupply_kW.createEmptyDataSets(v_activeEnergyCarriers, (int) (168 / p_tim
 						</Parameter>
 						<Parameter>
 							<Name><![CDATA[p_isSliderGC]]></Name>
+						</Parameter>
+						<Parameter>
+							<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
 						</Parameter>
 					</Parameters>
 					<ReplicationFlag>true</ReplicationFlag>
@@ -11794,6 +11806,9 @@ dsm_liveSupply_kW.createEmptyDataSets(v_activeEnergyCarriers, (int) (168 / p_tim
 						<Parameter>
 							<Name><![CDATA[p_address]]></Name>
 						</Parameter>
+						<Parameter>
+							<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
+						</Parameter>
 					</Parameters>
 					<ReplicationFlag>true</ReplicationFlag>
 					<Replication Class="CodeValue">
@@ -11950,6 +11965,9 @@ dsm_liveSupply_kW.createEmptyDataSets(v_activeEnergyCarriers, (int) (168 / p_tim
 						<Parameter>
 							<Name><![CDATA[p_address]]></Name>
 						</Parameter>
+						<Parameter>
+							<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
+						</Parameter>
 					</Parameters>
 					<ReplicationFlag>true</ReplicationFlag>
 					<Replication Class="CodeValue">
@@ -12105,6 +12123,9 @@ dsm_liveSupply_kW.createEmptyDataSets(v_activeEnergyCarriers, (int) (168 / p_tim
 						</Parameter>
 						<Parameter>
 							<Name><![CDATA[p_address]]></Name>
+						</Parameter>
+						<Parameter>
+							<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
 						</Parameter>
 					</Parameters>
 					<ReplicationFlag>true</ReplicationFlag>
@@ -12264,6 +12285,9 @@ dsm_liveSupply_kW.createEmptyDataSets(v_activeEnergyCarriers, (int) (168 / p_tim
 						</Parameter>
 						<Parameter>
 							<Name><![CDATA[p_isSliderGC]]></Name>
+						</Parameter>
+						<Parameter>
+							<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
 						</Parameter>
 					</Parameters>
 					<ReplicationFlag>true</ReplicationFlag>
@@ -12745,6 +12769,9 @@ dsm_liveSupply_kW.createEmptyDataSets(v_activeEnergyCarriers, (int) (168 / p_tim
 						<Parameter>
 							<Name><![CDATA[p_address]]></Name>
 						</Parameter>
+						<Parameter>
+							<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
+						</Parameter>
 					</Parameters>
 					<ReplicationFlag>true</ReplicationFlag>
 					<Replication Class="CodeValue">
@@ -12919,6 +12946,9 @@ dsm_liveSupply_kW.createEmptyDataSets(v_activeEnergyCarriers, (int) (168 / p_tim
 						</Parameter>
 						<Parameter>
 							<Name><![CDATA[p_municipality]]></Name>
+						</Parameter>
+						<Parameter>
+							<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
 						</Parameter>
 					</Parameters>
 					<ReplicationFlag>true</ReplicationFlag>
@@ -18842,7 +18872,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 				<Variable Class="PlainVariable">
 					<Id>1719407798845</Id>
 					<Name><![CDATA[v_totalInstalledWindPower_kW]]></Name>
-					<X>580</X><Y>450</Y>
+					<X>580</X><Y>460</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -18857,7 +18887,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 				<Variable Class="PlainVariable">
 					<Id>1719407798847</Id>
 					<Name><![CDATA[v_totalInstalledPVPower_kW]]></Name>
-					<X>580</X><Y>470</Y>
+					<X>580</X><Y>480</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -20012,7 +20042,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 				<Variable Class="Parameter">
 					<Id>1668695364192</Id>
 					<Name><![CDATA[p_batteryAsset]]></Name>
-					<X>600</X><Y>380</Y>
+					<X>600</X><Y>390</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -20057,7 +20087,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 				<Variable Class="Parameter">
 					<Id>1676449763319</Id>
 					<Name><![CDATA[p_heatBuffer]]></Name>
-					<X>600</X><Y>360</Y>
+					<X>600</X><Y>370</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -20078,7 +20108,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 				<Variable Class="Parameter">
 					<Id>1684919785784</Id>
 					<Name><![CDATA[p_gasBuffer]]></Name>
-					<X>600</X><Y>400</Y>
+					<X>600</X><Y>410</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -20099,7 +20129,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 				<Variable Class="Parameter">
 					<Id>1692878211840</Id>
 					<Name><![CDATA[p_cookingTracker]]></Name>
-					<X>740</X><Y>220</Y>
+					<X>740</X><Y>230</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -20141,7 +20171,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 				<Variable Class="Parameter">
 					<Id>1692973005119</Id>
 					<Name><![CDATA[p_DHWAsset]]></Name>
-					<X>741</X><Y>178</Y>
+					<X>741</X><Y>188</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -20463,10 +20493,34 @@ import javax.management.RuntimeErrorException;]]></Import>
 						</ParameterEditor>
 					</Properties>                 
 				</Variable>
+				<Variable Class="Parameter">
+					<Id>1732536517365</Id>
+					<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
+					<X>580</X><Y>140</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" ModificatorType="STATIC">
+						<Type><![CDATA[J_EAConversion]]></Type>
+						<UnitType><![CDATA[NONE]]></UnitType>
+						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[null]]></Code>
+						</DefaultValue>
+						<ParameterEditor>
+							<Id>1732536517363</Id>
+							<EditorContolType>TEXT_BOX</EditorContolType>
+							<MinSliderValue><![CDATA[0]]></MinSliderValue>
+							<MaxSliderValue><![CDATA[100]]></MaxSliderValue>
+							<DelimeterType>NO_DELIMETER</DelimeterType>
+						</ParameterEditor>
+					</Properties>                 
+				</Variable>
 				<Variable Class="CollectionVariable">
 					<Id>1659962626903</Id>
 					<Name><![CDATA[c_energyAssets]]></Name>
-					<X>580</X><Y>160</Y>
+					<X>580</X><Y>170</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -20481,7 +20535,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1659962626907</Id>
 					<Name><![CDATA[c_storageAssets]]></Name>
-					<X>600</X><Y>260</Y>
+					<X>600</X><Y>270</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -20496,7 +20550,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1659962626909</Id>
 					<Name><![CDATA[c_consumptionAssets]]></Name>
-					<X>600</X><Y>180</Y>
+					<X>600</X><Y>190</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -20511,7 +20565,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1659962626911</Id>
 					<Name><![CDATA[c_productionAssets]]></Name>
-					<X>600</X><Y>200</Y>
+					<X>600</X><Y>210</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -20526,7 +20580,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1659962626913</Id>
 					<Name><![CDATA[c_conversionAssets]]></Name>
-					<X>600</X><Y>220</Y>
+					<X>600</X><Y>230</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -20541,7 +20595,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1667746389220</Id>
 					<Name><![CDATA[c_vehicleAssets]]></Name>
-					<X>600</X><Y>280</Y>
+					<X>600</X><Y>290</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -20556,7 +20610,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1668359033654</Id>
 					<Name><![CDATA[c_vehiclesAvailableForCharging]]></Name>
-					<X>620</X><Y>300</Y>
+					<X>620</X><Y>310</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -20571,7 +20625,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1669115948280</Id>
 					<Name><![CDATA[c_dieselVehicles]]></Name>
-					<X>620</X><Y>320</Y>
+					<X>620</X><Y>330</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -20586,7 +20640,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1692864624612</Id>
 					<Name><![CDATA[c_tripTrackers]]></Name>
-					<X>720</X><Y>280</Y>
+					<X>720</X><Y>290</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -20601,7 +20655,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1700044359363</Id>
 					<Name><![CDATA[c_profileAssets]]></Name>
-					<X>740</X><Y>160</Y>
+					<X>740</X><Y>170</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -20631,7 +20685,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 				<Variable Class="CollectionVariable">
 					<Id>1711012701187</Id>
 					<Name><![CDATA[c_hydrogenVehicles]]></Name>
-					<X>620</X><Y>340</Y>
+					<X>620</X><Y>350</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -41152,6 +41206,9 @@ public void f_simpleCharging(){
 				<Parameter>
 					<Name><![CDATA[p_address]]></Name>
 				</Parameter>
+				<Parameter>
+					<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
+				</Parameter>
 			</Parameters>
 			<Generic>false</Generic>
 			<GenericParameter>
@@ -43223,6 +43280,9 @@ public void f_connectToJ_EA(J_EA j_ea){
 				<Parameter>
 					<Name><![CDATA[p_address]]></Name>
 				</Parameter>
+				<Parameter>
+					<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
+				</Parameter>
 			</Parameters>
 			<Generic>false</Generic>
 			<GenericParameter>
@@ -44307,6 +44367,9 @@ public void f_operateFlexAssets(){
 				<Parameter>
 					<Name><![CDATA[p_address]]></Name>
 				</Parameter>
+				<Parameter>
+					<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
+				</Parameter>
 			</Parameters>
 			<Generic>false</Generic>
 			<GenericParameter>
@@ -44791,6 +44854,9 @@ public void f_fillAnnualDataSets() {
 				</Parameter>
 				<Parameter>
 					<Name><![CDATA[p_address]]></Name>
+				</Parameter>
+				<Parameter>
+					<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
 				</Parameter>
 			</Parameters>
 			<Generic>false</Generic>
@@ -46558,6 +46624,9 @@ public void f_operateFlexAssets(){
 				<Parameter>
 					<Name><![CDATA[p_address]]></Name>
 				</Parameter>
+				<Parameter>
+					<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
+				</Parameter>
 			</Parameters>
 			<Generic>false</Generic>
 			<GenericParameter>
@@ -47234,6 +47303,9 @@ public void f_calculateEnergyBalance(){
 				</Parameter>
 				<Parameter>
 					<Name><![CDATA[p_address]]></Name>
+				</Parameter>
+				<Parameter>
+					<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
 				</Parameter>
 			</Parameters>
 			<Generic>false</Generic>
@@ -48563,6 +48635,9 @@ public void f_resetSpecificGCStates(){
 				</Parameter>
 				<Parameter>
 					<Name><![CDATA[p_address]]></Name>
+				</Parameter>
+				<Parameter>
+					<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
 				</Parameter>
 			</Parameters>
 			<Generic>false</Generic>
@@ -50053,6 +50128,9 @@ public void f_operateFlexAssets(){
 				<Parameter>
 					<Name><![CDATA[p_address]]></Name>
 				</Parameter>
+				<Parameter>
+					<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
+				</Parameter>
 			</Parameters>
 			<Generic>false</Generic>
 			<GenericParameter>
@@ -50588,6 +50666,9 @@ public void f_connectToJ_EA_default(J_EA j_ea){
 				<Parameter>
 					<Name><![CDATA[p_address]]></Name>
 				</Parameter>
+				<Parameter>
+					<Name><![CDATA[p_quaternaryHeatingAsset]]></Name>
+				</Parameter>
 			</Parameters>
 			<Generic>false</Generic>
 			<GenericParameter>
@@ -50730,7 +50811,7 @@ public void f_connectToJ_EA_default(J_EA j_ea){
 				<Variable Class="PlainVariable">
 					<Id>1722514805108</Id>
 					<Name><![CDATA[v_amountOfGasBurners_houses_fr]]></Name>
-					<X>1690</X><Y>150</Y>
+					<X>1690</X><Y>170</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -50742,7 +50823,7 @@ public void f_connectToJ_EA_default(J_EA j_ea){
 				<Variable Class="PlainVariable">
 					<Id>1722514809527</Id>
 					<Name><![CDATA[v_amountOfHybridHeatpump_houses_fr]]></Name>
-					<X>1690</X><Y>170</Y>
+					<X>1690</X><Y>190</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -50754,7 +50835,7 @@ public void f_connectToJ_EA_default(J_EA j_ea){
 				<Variable Class="PlainVariable">
 					<Id>1722514811890</Id>
 					<Name><![CDATA[v_amountOfElectricHeatpumps_houses_fr]]></Name>
-					<X>1690</X><Y>190</Y>
+					<X>1690</X><Y>210</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -50766,7 +50847,7 @@ public void f_connectToJ_EA_default(J_EA j_ea){
 				<Variable Class="PlainVariable">
 					<Id>1722514815083</Id>
 					<Name><![CDATA[v_amountOfDistrictHeating_houses_fr]]></Name>
-					<X>1690</X><Y>210</Y>
+					<X>1690</X><Y>230</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -50778,13 +50859,28 @@ public void f_connectToJ_EA_default(J_EA j_ea){
 				<Variable Class="PlainVariable">
 					<Id>1724397994084</Id>
 					<Name><![CDATA[v_nbCurrentHouseholdsWithBattery]]></Name>
-					<X>1680</X><Y>460</Y>
+					<X>1680</X><Y>470</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
 						<Type><![CDATA[int]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1732535845737</Id>
+					<Name><![CDATA[v_amountOfHydrogenUseForHeating_companies_fr]]></Name>
+					<X>1690</X><Y>140</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+						<InitialValue Class="CodeValue">
+							<Code><![CDATA[0]]></Code>
+						</InitialValue>
 					</Properties>
 				</Variable>
 				<Variable Class="Parameter">
@@ -50813,7 +50909,7 @@ public void f_connectToJ_EA_default(J_EA j_ea){
 					<Id>1722588367044</Id>
 					<Name><![CDATA[p_thresholdCOP_hybridHeatpump]]></Name>
 					<Description><![CDATA[Threshold for when the gas burner needs to kick in in a hybrid heatpump system]]></Description>
-					<X>1720</X><Y>340</Y>
+					<X>1720</X><Y>360</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -50922,7 +51018,7 @@ public void f_connectToJ_EA_default(J_EA j_ea){
 				<Variable Class="CollectionVariable">
 					<Id>1722589144737</Id>
 					<Name><![CDATA[c_heatDemandEA]]></Name>
-					<X>1690</X><Y>370</Y>
+					<X>1690</X><Y>390</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -50942,7 +51038,7 @@ public void f_connectToJ_EA_default(J_EA j_ea){
 					<Id>1719849166911</Id>
 					<Name><![CDATA[f_operateFlexAssets_overwrite]]></Name>
 					<X>910</X><Y>220</Y>
-					<Label><X>20</X><Y>0</Y></Label>
+					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
@@ -50978,7 +51074,7 @@ if( p_batteryAsset != null && p_batteryAsset.getStorageCapacity_kWh() != 0){
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1722514612938</Id>
 					<Name><![CDATA[f_setHeatingMethodPct_companies]]></Name>
-					<X>1690</X><Y>250</Y>
+					<X>1690</X><Y>270</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -50987,10 +51083,13 @@ if( p_batteryAsset != null && p_batteryAsset.getStorageCapacity_kWh() != 0){
 						<Name><![CDATA[pctArray]]></Name>
 						<Type><![CDATA[double[]]]></Type>
 					</Parameter>
-					<Body><![CDATA[v_amountOfGasBurners_companies_fr = pctArray[0]/100;
-v_amountOfElectricHeatpumps_companies_fr = pctArray[1]/100;
-v_amountOfHybridHeatpump_companies_fr = pctArray[2]/100;
-v_amountOfDistrictHeating_companies_fr = pctArray[3]/100;
+					<Body><![CDATA[//Calculate actual space heating 
+double actualHeatingDemandSpaceHeating_fr =  (1 - v_amountOfHydrogenUseForHeating_companies_fr);
+
+v_amountOfGasBurners_companies_fr = actualHeatingDemandSpaceHeating_fr * pctArray[0]/100;
+v_amountOfElectricHeatpumps_companies_fr = actualHeatingDemandSpaceHeating_fr * pctArray[1]/100;
+v_amountOfHybridHeatpump_companies_fr = actualHeatingDemandSpaceHeating_fr * pctArray[2]/100;
+v_amountOfDistrictHeating_companies_fr = actualHeatingDemandSpaceHeating_fr * pctArray[3]/100;
 
 ]]></Body>
 				</Function>
@@ -50999,7 +51098,7 @@ v_amountOfDistrictHeating_companies_fr = pctArray[3]/100;
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1722514620314</Id>
 					<Name><![CDATA[f_setHeatingMethodPct_houses]]></Name>
-					<X>1690</X><Y>280</Y>
+					<X>1690</X><Y>290</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -51029,18 +51128,19 @@ v_amountOfDistrictHeating_houses_fr = pctArray[3]/100;
 	return;
 }
 
-//Division of the power demand
-double powerDemandDivision[] = f_dividePowerDemandHeatingAssets();
+//Division of the power demand //{Gasburner power request, HP power request, DH power request, Hydrogenburner power request}
+double powerDemandDivision[] = f_dividePowerDemandHeatingAssets(); 
 
 //Split the power fractions (powerDemandDivision[] = {Gasburner power request, HP power request, DH power request}
 double powerFraction_GASBURNER = min(1, powerDemandDivision[0] / p_primaryHeatingAsset.getCapacityHeat_kW()); 
 double powerFraction_HEATPUMP  = min(1, powerDemandDivision[1] / p_secondaryHeatingAsset.getCapacityHeat_kW());
-//double powerFraction_HEATDELIVERYSET = min(1, powerDemandDivision[2] / p_tertiaryHeatingAsset.getCapacityHeat_kW());
+double powerFraction_HEATDELIVERYSET = min(1, powerDemandDivision[2] / p_tertiaryHeatingAsset.getCapacityHeat_kW());
+double powerFraction_HYDROGENBURNER = min(1, powerDemandDivision[3] / p_quaternaryHeatingAsset.getCapacityHeat_kW());
 
-//p_primaryHeatingAsset.v_powerFraction_fr = powerFraction_GASBURNER;
-//p_secondaryHeatingAsset.v_powerFraction_fr = powerFraction_HEATPUMP;
-//p_tertiaryHeatingAsset.v_powerFraction_fr = powerFraction_HEATDELIVERYSET;			
-			
+p_primaryHeatingAsset.v_powerFraction_fr = powerFraction_GASBURNER;
+p_secondaryHeatingAsset.v_powerFraction_fr = powerFraction_HEATPUMP;
+p_tertiaryHeatingAsset.v_powerFraction_fr = powerFraction_HEATDELIVERYSET;			
+p_quaternaryHeatingAsset.v_powerFraction_fr = powerFraction_HYDROGENBURNER;	
 		
 //Gas burner control (always assigned to primary heating asset)	
 p_primaryHeatingAsset.f_updateAllFlows(powerFraction_GASBURNER);
@@ -51049,7 +51149,10 @@ p_primaryHeatingAsset.f_updateAllFlows(powerFraction_GASBURNER);
 p_secondaryHeatingAsset.f_updateAllFlows(powerFraction_HEATPUMP);
 
 //Heat delivery set control (always assigned to tertiary heating asset)
-//p_tertiaryHeatingAsset.f_updateAllFlows(powerFraction_HEATDELIVERYSET);
+p_tertiaryHeatingAsset.f_updateAllFlows(powerFraction_HEATDELIVERYSET);
+
+//Hydrogen burner(always assigned to quaternary heating asset)
+p_quaternaryHeatingAsset.f_updateAllFlows(powerFraction_HYDROGENBURNER);
 ]]></Body>
 				</Function>
 				<Function AccessType="default" StaticFunction="false">
@@ -51057,19 +51160,18 @@ p_secondaryHeatingAsset.f_updateAllFlows(powerFraction_HEATPUMP);
 					<ReturnType><![CDATA[double[]]]></ReturnType>
 					<Id>1722587530130</Id>
 					<Name><![CDATA[f_dividePowerDemandHeatingAssets]]></Name>
-					<X>1690</X><Y>320</Y>
+					<X>1690</X><Y>340</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Body><![CDATA[//Initialize power demand division array
-double powerDemandDivision[] = {0, 0, 0}; // {Gasburner power request, HP power request, DH power request}
+double powerDemandDivision[] = {0, 0, 0, 0}; // {Gasburner power request, HP power request, DH power request, Hydrogenburner power request}
 
 //Demanded total heating power at the current time step
 double powerDemand_kW = fm_currentBalanceFlows_kW.get(OL_EnergyCarriers.HEAT);
 
 //Demanded heating power for companies and household seperatly the current time step
-
 double powerDemand_companies_kW = max(0,c_heatDemandEA.get("COMPANIES").getLastFlows().get(OL_EnergyCarriers.HEAT));
 double powerDemand_households_kW = max(0,c_heatDemandEA.get("HOUSEHOLDS").getLastFlows().get(OL_EnergyCarriers.HEAT));
 
@@ -51081,19 +51183,21 @@ double HP_COP = ((J_EAConversionHeatPump)p_secondaryHeatingAsset).getCOP();
 double gasBurnerPowerDemand 		= powerDemand_companies_kW*v_amountOfGasBurners_companies_fr		 + powerDemand_households_kW*v_amountOfGasBurners_houses_fr;
 double electricHPPowerDemand 		= powerDemand_companies_kW*v_amountOfElectricHeatpumps_companies_fr + powerDemand_households_kW*v_amountOfElectricHeatpumps_houses_fr;
 double hybridHPPowerDemand 	   		= powerDemand_companies_kW*v_amountOfHybridHeatpump_companies_fr	 + powerDemand_households_kW*v_amountOfHybridHeatpump_houses_fr;
-//double DistrictHeatingPowerDemand = powerDemand_companies_kW*v_amountOfDistrictHeating_companies_pct	 + powerDemand_households_kW*v_amountOfDistrictHeating_houses_pct;
-double DistrictHeatingPowerDemand 	= (powerDemand_companies_kW+powerDemand_households_kW) - hybridHPPowerDemand - electricHPPowerDemand - gasBurnerPowerDemand; // To make sure all power demand is met
-
+double districtHeatingPowerDemand   = powerDemand_companies_kW*v_amountOfDistrictHeating_companies_fr	 + powerDemand_households_kW*v_amountOfDistrictHeating_houses_fr;
+//double hydrogenBurnerPowerDemand	= powerDemand_companies_kW*v_amountOfHydrogenUseForHeating_companies_fr;
+double hydrogenBurnerPowerDemand 	= (powerDemand_companies_kW+powerDemand_households_kW) - hybridHPPowerDemand - electricHPPowerDemand - gasBurnerPowerDemand - districtHeatingPowerDemand; // To make sure all power demand is met
 
 if ( HP_COP < p_thresholdCOP_hybridHeatpump ) { // switch to gasburner when HP COP is below treshold
 	powerDemandDivision[0] = gasBurnerPowerDemand + hybridHPPowerDemand;
 	powerDemandDivision[1] = electricHPPowerDemand;
-	powerDemandDivision[2] = DistrictHeatingPowerDemand;
+	powerDemandDivision[2] = districtHeatingPowerDemand;
+	powerDemandDivision[3] = hydrogenBurnerPowerDemand;
 }
 else{
 	powerDemandDivision[0] = gasBurnerPowerDemand;
 	powerDemandDivision[1] = electricHPPowerDemand + hybridHPPowerDemand;
-	powerDemandDivision[2] = DistrictHeatingPowerDemand;
+	powerDemandDivision[2] = districtHeatingPowerDemand;
+	powerDemandDivision[3] = hydrogenBurnerPowerDemand;
 }
 
 /*
@@ -51103,7 +51207,7 @@ else{
 	powerDemandDivision[2] = 0;
 */
 
-return powerDemandDivision; //{Gasburner power request, HP power request, DH power request}]]></Body>
+return powerDemandDivision; //{Gasburner power request, HP power request, DH power request, Hydrogenburner power request}]]></Body>
 				</Function>
 				<Function AccessType="default" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
@@ -51240,7 +51344,7 @@ if (j_ea instanceof J_EAVehicle) {
 					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1730370456790</Id>
 					<Name><![CDATA[f_connectToJ_EA_default_overwrite]]></Name>
-					<X>1070</X><Y>140</Y>
+					<X>1070</X><Y>90</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -51364,6 +51468,8 @@ if (j_ea instanceof J_EAVehicle) {
 		p_secondaryHeatingAsset = (J_EAConversion)j_ea;
 	} else if (j_ea instanceof J_EAConversionHeatDeliverySet) {
 		p_tertiaryHeatingAsset = (J_EAConversion)j_ea;
+	} else if (j_ea instanceof J_EAConversionHydrogenBurner) {
+		p_quaternaryHeatingAsset = (J_EAConversion)j_ea;
 	}
 } else if  (j_ea instanceof J_EAStorage) {
 	c_storageAssets.add((J_EAStorage)j_ea);
@@ -51538,6 +51644,25 @@ if (p_batteryAsset.getStorageCapacity_kWh() != 0){
 }
 ]]></Body>
 				</Function>
+				<Function AccessType="public" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1732550952237</Id>
+					<Name><![CDATA[f_setH2HeatingFr_companies]]></Name>
+					<X>1690</X><Y>310</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Parameter>
+						<Name><![CDATA[amountOfHydrogenUseForHeating]]></Name>
+						<Type><![CDATA[double]]></Type>
+					</Parameter>
+					<Body><![CDATA[double maximumHydrogenUsedForHeating_companies_fr = 1; // For now
+
+v_amountOfHydrogenUseForHeating_companies_fr = max(0,min(maximumHydrogenUsedForHeating_companies_fr,amountOfHydrogenUseForHeating));
+]]></Body>
+				</Function>
 			</Functions>
 			<AgentLinks>
 				<AgentLink>
@@ -51595,7 +51720,7 @@ if (p_batteryAsset.getStorageCapacity_kWh() != 0){
 				<Rectangle>
 					<Id>1722502672021</Id>
 					<Name><![CDATA[rect_heatSliderFunctionality]]></Name>
-					<X>1650</X><Y>0</Y>
+					<X>1650</X><Y>10</Y>
 					<Label><X>10</X><Y>10</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -51609,8 +51734,8 @@ if (p_batteryAsset.getStorageCapacity_kWh() != 0){
 					<LineColor>-65536</LineColor>
 					<LineMaterial>null</LineMaterial>
 					<LineStyle>SOLID</LineStyle>
-					<Width>430</Width>
-					<Height>390</Height>
+					<Width>470</Width>
+					<Height>400</Height>
 					<Rotation>0.0</Rotation>
 					<FillColor>-1</FillColor>
 					<FillMaterial>null</FillMaterial>
@@ -51639,7 +51764,7 @@ if (p_batteryAsset.getStorageCapacity_kWh() != 0){
 				<Rectangle>
 					<Id>1724397965238</Id>
 					<Name><![CDATA[rect_batterySliderFunctionality]]></Name>
-					<X>1650</X><Y>400</Y>
+					<X>1650</X><Y>420</Y>
 					<Label><X>10</X><Y>10</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -51661,7 +51786,7 @@ if (p_batteryAsset.getStorageCapacity_kWh() != 0){
 				<Text>
 					<Id>1724397981363</Id>
 					<Name><![CDATA[txt_batterySliderFunctionality]]></Name>
-					<X>1670</X><Y>420</Y>
+					<X>1670</X><Y>430</Y>
 					<Label><X>0</X><Y>-10</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -54007,8 +54132,6 @@ public class J_EAEV extends J_EAVehicle implements Serializable {
  */
 public class J_EAConversionHeatDeliverySet extends zero_engine.J_EAConversion implements Serializable {
 
-	private OL_EnergyCarriers energyCarrierProduced = OL_EnergyCarriers.HEAT;
-	private OL_EnergyCarriers energyCarrierConsumed = OL_EnergyCarriers.HEAT;
 	protected double outputTemperature_degC;
     /**
      * Default constructor
@@ -54022,9 +54145,11 @@ public class J_EAConversionHeatDeliverySet extends zero_engine.J_EAConversion im
     public J_EAConversionHeatDeliverySet(Agent parentAgent, double capacityThermal_kW, double efficiency, double outputTemperature_degC, double timestep_h) {
 	    this.parentAgent = parentAgent;
 	    this.eta_r = efficiency;
-	    this.inputCapacity_kW = capacityThermal_kW * eta_r;	 
+	    this.inputCapacity_kW = capacityThermal_kW / eta_r;	 
 	    this.outputTemperature_degC = outputTemperature_degC;
 	    this.timestep_h = timestep_h;
+    	this.energyCarrierProduced = OL_EnergyCarriers.HEAT;
+    	this.energyCarrierConsumed= OL_EnergyCarriers.HEAT;  
 	    activeEnergyCarriers.add(this.energyCarrierProduced);
 	    registerEnergyAsset();
 	}
@@ -54324,53 +54449,52 @@ public class J_ActorData implements Serializable {
 			<Id>1665502017804</Id>
 			<Name><![CDATA[J_EAConversionHydrogenBurner]]></Name>
 			<Text><![CDATA[/**
- * J_EAConversionGasBurner
- */
+* J_EAConversionGasBurner
+*/
 public class J_EAConversionHydrogenBurner extends zero_engine.J_EAConversion implements Serializable {
-
-	private OL_EnergyCarriers energyCarrierProduced = OL_EnergyCarriers.HEAT;
-	private OL_EnergyCarriers energyCarrierConsumed = OL_EnergyCarriers.HYDROGEN;
+ 
 	protected double outputTemperature_degC;
-	protected double capacityHeat_kW;
     /**
      * Default constructor
      */
     public J_EAConversionHydrogenBurner() {
     }
-
+ 
     /**
      * Constructor initializing the fields
      */
     public J_EAConversionHydrogenBurner(Agent parentAgent, OL_EnergyAssetType assetType, double capacityThermal_kW, double efficiency, double timestep_h, double outputTemperature_degC) {
 	    this.parentAgent = parentAgent;
 	    this.energyAssetType = assetType;
-	    this.capacityHeat_kW = capacityThermal_kW;
 	    this.eta_r = efficiency;
+	    this.inputCapacity_kW = capacityThermal_kW / this.eta_r;
 	    this.timestep_h = timestep_h;
 	    this.outputTemperature_degC = outputTemperature_degC;
-	    //this.energyAssetType = OL_EnergyAssetType.HYDROGEN_FURNACE;
+	    this.energyCarrierProduced = OL_EnergyCarriers.HEAT;
+	    this.energyCarrierConsumed = OL_EnergyCarriers.HYDROGEN;
 	    activeEnergyCarriers.add(this.energyCarrierProduced);
 	    activeEnergyCarriers.add(this.energyCarrierConsumed);
 		registerEnergyAsset();
 	}
-
+ 
     @Override
     public void operate(double ratioOfCapacity) {
 		//traceln("I convert now! GasBurner @ " + (ratioOfCapacity * 100) + " %");
-		double heatProduction_kW = capacityHeat_kW * ratioOfCapacity;
-		double hydrogenConsumption_kW = heatProduction_kW / eta_r;
+    	double hydrogenConsumption_kW = ratioOfCapacity * this.inputCapacity_kW;
+    	double heatProduction_kW = hydrogenConsumption_kW * this.eta_r;
+		
 		this.energyUse_kW = (hydrogenConsumption_kW - heatProduction_kW);
 		this.energyUsed_kWh += timestep_h * energyUse_kW; // This represents losses!
 		//double[] arr = {this.electricityProduction_kW, this.methaneProduction_kW, this.hydrogenProduction_kW, this.heatProduction_kW, this.electricityConsumption_kW, this.methaneConsumption_kW, this.hydrogenConsumption_kW, this.heatConsumption_kW };
     	//return arr;
 		this.heatProduced_kWh += heatProduction_kW * timestep_h;
-
+ 
 		flowsMap.put(OL_EnergyCarriers.HEAT, -heatProduction_kW);		
 		flowsMap.put(OL_EnergyCarriers.HYDROGEN, hydrogenConsumption_kW);		
 		//return new Pair(flowsMap, this.energyUse_kW);
-
+ 
     }
-
+ 
 	public double getEnergyUsed_kWh() {
 		return energyUsed_kWh;
 	}
@@ -54378,9 +54502,8 @@ public class J_EAConversionHydrogenBurner extends zero_engine.J_EAConversion imp
 	@Override
 	public String toString() {
 		return
-			"AssetType = " + energyAssetType + 
+			"AssetType = " + energyAssetType +
 			" parentAgent = " + parentAgent +", Energy consumed = " + this.energyUsed_kWh +
-			"capacityHeat_kW = " + this.capacityHeat_kW +" "+
 			"eta_r = " + this.eta_r+" " +
 			"outputTemperature_degC = " + this.outputTemperature_degC + " "+
 			"energyUsed_kWh (losses) = " + this.energyUsed_kWh + " "+
@@ -54391,13 +54514,13 @@ public class J_EAConversionHydrogenBurner extends zero_engine.J_EAConversion imp
 	public double getCurrentTemperature() {
 		return outputTemperature_degC;
 	}
-
+ 
 	/**
 	 * This number is here for model snapshot storing purpose<br>
 	 * It needs to be changed when this class gets changed
 	 */
 	private static final long serialVersionUID = 1L;
-
+ 
 }]]></Text>
 		</JavaClass>
 		<!--   =========   Java Class   ========  -->
@@ -54409,8 +54532,6 @@ public class J_EAConversionHydrogenBurner extends zero_engine.J_EAConversion imp
  */
 public class J_EAConversionElectricHeater extends J_EAConversion implements Serializable {
 
-	private OL_EnergyCarriers energyCarrierProduced = OL_EnergyCarriers.HEAT;
-	private OL_EnergyCarriers energyCarrierConsumed = OL_EnergyCarriers.ELECTRICITY;
 	protected double outputTemperature_degC;
     /**
      * Default constructor
@@ -54422,6 +54543,8 @@ public class J_EAConversionElectricHeater extends J_EAConversion implements Seri
 	    //this.capacityHeat_kW = this.capacityElectric_kW * this.eta_r;
 	    this.timestep_h = timestep_h;
 	    this.outputTemperature_degC = outputTemperature_degC;
+	    this.energyCarrierProduced = OL_EnergyCarriers.HEAT;
+	    this.energyCarrierConsumed = OL_EnergyCarriers.ELECTRICITY;
 	    activeEnergyCarriers.add(this.energyCarrierProduced);
 	    activeEnergyCarriers.add(this.energyCarrierConsumed);
 		registerEnergyAsset();
@@ -54906,9 +55029,6 @@ public class J_EAHydrogenVehicle extends J_EAVehicle implements Serializable {
  */
 public class J_EAConversionElektrolyser extends zero_engine.J_EAConversion implements Serializable {
 
-	private OL_EnergyCarriers energyCarrierProduced = OL_EnergyCarriers.HYDROGEN;
-	private OL_EnergyCarriers energyCarrierConsumed = OL_EnergyCarriers.ELECTRICITY;
-	protected double capacityElectric_kW;
     /**
 	/**
      * Default constructor
@@ -54921,9 +55041,11 @@ public class J_EAConversionElektrolyser extends zero_engine.J_EAConversion imple
      */
     public J_EAConversionElektrolyser(Agent parentAgent, double capacityElectric_kW, double efficiency_r, double  timestep_h) {
 	    this.parentAgent = parentAgent;
-	    this.capacityElectric_kW = capacityElectric_kW;
+	    this.inputCapacity_kW = capacityElectric_kW;
 	    this.eta_r = efficiency_r;
 	    this.timestep_h = timestep_h;
+	    this.energyCarrierProduced = OL_EnergyCarriers.HYDROGEN;
+	    this.energyCarrierConsumed = OL_EnergyCarriers.ELECTRICITY;	  
 	    activeEnergyCarriers.add(this.energyCarrierProduced);
 	    activeEnergyCarriers.add(this.energyCarrierConsumed);
 		registerEnergyAsset();
@@ -54933,7 +55055,7 @@ public class J_EAConversionElektrolyser extends zero_engine.J_EAConversion imple
     public void operate(double ratioOfCapacity) {
 		//traceln("I convert now! GasBurner @ " + (ratioOfCapacity * 100) + " %");
     	ratioOfCapacity=max(0,ratioOfCapacity); // Prevent negative elektrolyser power. This is not a fuel cell! ^^
-		double electricityConsumption_kW = capacityElectric_kW * ratioOfCapacity;
+		double electricityConsumption_kW = inputCapacity_kW * ratioOfCapacity;
     	double hydrogenProduction_kW = electricityConsumption_kW * eta_r;
     	this.energyUse_kW = (electricityConsumption_kW - hydrogenProduction_kW);
 		this.energyUsed_kWh += timestep_h * energyUse_kW; // This represents losses! Optionally, this could also be a waste-heat source
@@ -54956,7 +55078,7 @@ public class J_EAConversionElektrolyser extends zero_engine.J_EAConversion imple
 	public String toString() {
 		return
 			"parentAgent = " + parentAgent +" " +
-			"capacityElectric_kW = " + this.capacityElectric_kW +" "+
+			"capacityElectric_kW = " + this.inputCapacity_kW +" "+
 			"eta_r = " + this.eta_r+" ";
 	}
 
@@ -54980,8 +55102,6 @@ public class J_EAConversionElektrolyser extends zero_engine.J_EAConversion imple
  */
 public class J_EAConversionGasCHP extends zero_engine.J_EAConversion implements Serializable {
 
-	private OL_EnergyCarriers energyCarrierProduced = OL_EnergyCarriers.ELECTRICITY;
-	private OL_EnergyCarriers energyCarrierConsumed = OL_EnergyCarriers.METHANE;
 	protected double outputTemperature_degC;
 	protected double capacityHeat_kW;
 	protected double capacityElectric_kW;
@@ -55001,6 +55121,8 @@ public class J_EAConversionGasCHP extends zero_engine.J_EAConversion implements 
 	    this.capacityHeat_kW = capacityHeat_kW; 
 	    this.timestep_h = timestep_h;
 	    this.outputTemperature_degC = outputTemperature_degC;
+    	this.energyCarrierProduced = OL_EnergyCarriers.ELECTRICITY;
+    	this.energyCarrierConsumed= OL_EnergyCarriers.METHANE;        
 	    activeEnergyCarriers.add(this.energyCarrierProduced);
 	    activeEnergyCarriers.add(this.energyCarrierConsumed);
 	    activeEnergyCarriers.add(OL_EnergyCarriers.HEAT);
@@ -55822,8 +55944,6 @@ public class J_ActivityTrackerCooking extends zero_engine.J_ActivityTracker impl
  */
 public class J_EAConversionElectrolyser extends zero_engine.J_EAConversion implements Serializable {
 
-	private OL_EnergyCarriers energyCarrierProduced = OL_EnergyCarriers.HYDROGEN;
-	private OL_EnergyCarriers energyCarrierConsumed = OL_EnergyCarriers.ELECTRICITY;
     private OL_ElectrolyserState state;
     private int remaining_power_up_duration; // amount of time steps left in power up mode
     private double startUpTimeStandby_h;
@@ -55845,7 +55965,8 @@ public class J_EAConversionElectrolyser extends zero_engine.J_EAConversion imple
 	    this.timestep_h = timestep_h;
 	    this.state = state;
 	    this.startUpTimeStandby_h = startUpTimeStandby_s/3600;
-	    
+	    this.energyCarrierProduced = OL_EnergyCarriers.HYDROGEN;
+	    this.energyCarrierConsumed = OL_EnergyCarriers.ELECTRICITY;	    
 		this.energyAssetType = OL_EnergyAssetType.ELECTROLYSER;
 	    
 	    //toegevoegd door Ate
@@ -55905,10 +56026,6 @@ public class J_EAConversionElectrolyser extends zero_engine.J_EAConversion imple
 		return this.eta_r;
 	}
 	
-	public double getCapacityElectric_kW( ) {
-		return this.inputCapacity_kW;
-	}
-	
 	public OL_ElectrolyserState getState() { // Used for regime control
     	return this.state;
     }
@@ -55950,9 +56067,6 @@ public class J_EAConversionElectrolyser extends zero_engine.J_EAConversion imple
  */
 public class J_EAConversionFuelCell extends zero_engine.J_EAConversion implements Serializable {
 
-	private OL_EnergyCarriers energyCarrierProduced = OL_EnergyCarriers.ELECTRICITY;
-	private OL_EnergyCarriers energyCarrierConsumed = OL_EnergyCarriers.HYDROGEN;
-
     /**
 	/**
      * Default constructor
@@ -55969,6 +56083,8 @@ public class J_EAConversionFuelCell extends zero_engine.J_EAConversion implement
 	    this.inputCapacity_kW = capacityElectric_kW/eta_r;
 	    this.timestep_h = timestep_h;
 	    this.energyAssetType = OL_EnergyAssetType.FUEL_CELL;
+	    this.energyCarrierProduced = OL_EnergyCarriers.ELECTRICITY;
+	    this.energyCarrierConsumed = OL_EnergyCarriers.HYDROGEN;	  
 	    activeEnergyCarriers.add(this.energyCarrierProduced);
 	    activeEnergyCarriers.add(this.energyCarrierConsumed);
 		registerEnergyAsset();


### PR DESCRIPTION
…ng (ONLY FOR COMPANIES). Conversion asset fixes: errors due to overriding of energyCarrierProduced and energyCarrierConsumed in J_EAConversion assets are now fixed for all assets that needed fixing.

- GCNeighborhood, now also possible to use hydrogen as source for heating (ONLY FOR COMPANIES).
- Conversion asset fixes: errors due to overriding of energyCarrierProduced and energyCarrierConsumed in J_EAConversion assets are now fixed for all assets that needed fixing. (All except gasburner and heatpump basically).
- Heat delivery set functions again as it should.