### PR TITLE
Cooking updates

### DIFF
--- a/Zero_engine.alpx
+++ b/Zero_engine.alpx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AnyLogicWorkspace splitVersion="1"
                    WorkspaceVersion="1.9"
-                   AnyLogicVersion="8.9.2.202410172110"
+                   AnyLogicVersion="8.9.2.202410172112"
                    AlpVersion="8.9.2">
 	<Model>
 		<Id>1658477103134</Id>

--- a/_alp/Agents/EnergyCoop/AOC.EnergyCoop.xml
+++ b/_alp/Agents/EnergyCoop/AOC.EnergyCoop.xml
@@ -125,7 +125,7 @@ import java.util.EnumSet;]]></Import>
 			<Name><![CDATA[data_naturalGasDemand_kW]]></Name>
 			<ExcludeFromBuild>true</ExcludeFromBuild>
 			<X>60</X>
-			<Y>1450</Y>
+			<Y>1430</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -153,7 +153,7 @@ import java.util.EnumSet;]]></Import>
 			<Id>1709636537281</Id>
 			<Name><![CDATA[data_heatPumpElectricityDemand_kW]]></Name>
 			<X>60</X>
-			<Y>1530</Y>
+			<Y>1510</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -265,7 +265,7 @@ import java.util.EnumSet;]]></Import>
 			<Id>1709636537321</Id>
 			<Name><![CDATA[data_batteryCharging_kW]]></Name>
 			<X>60</X>
-			<Y>1570</Y>
+			<Y>1550</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -293,7 +293,7 @@ import java.util.EnumSet;]]></Import>
 			<Id>1709636537330</Id>
 			<Name><![CDATA[data_baseloadElectricityDemand_kW]]></Name>
 			<X>60</X>
-			<Y>1510</Y>
+			<Y>1490</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -350,7 +350,7 @@ import java.util.EnumSet;]]></Import>
 			<Name><![CDATA[data_dieselDemand_kW]]></Name>
 			<ExcludeFromBuild>true</ExcludeFromBuild>
 			<X>60</X>
-			<Y>1469</Y>
+			<Y>1449</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -378,7 +378,7 @@ import java.util.EnumSet;]]></Import>
 			<Id>1709636537360</Id>
 			<Name><![CDATA[data_electricVehicleDemand_kW]]></Name>
 			<X>60</X>
-			<Y>1550</Y>
+			<Y>1530</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -435,7 +435,7 @@ import java.util.EnumSet;]]></Import>
 			<Name><![CDATA[data_hydrogenDemand_kW]]></Name>
 			<ExcludeFromBuild>true</ExcludeFromBuild>
 			<X>60</X>
-			<Y>1490</Y>
+			<Y>1470</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -516,8 +516,8 @@ import java.util.EnumSet;]]></Import>
 		<DataSet>
 			<Id>1723103882837</Id>
 			<Name><![CDATA[data_annualWindGeneration_kW]]></Name>
-			<X>392.66666666666663</X>
-			<Y>2125.333333333333</Y>
+			<X>392.667</X>
+			<Y>2135.333</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -542,8 +542,8 @@ import java.util.EnumSet;]]></Import>
 		<DataSet>
 			<Id>1723103882840</Id>
 			<Name><![CDATA[data_annualV2GSupply_kW]]></Name>
-			<X>392.66666666666663</X>
-			<Y>2165.333333333333</Y>
+			<X>392.667</X>
+			<Y>2175.333</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -568,8 +568,8 @@ import java.util.EnumSet;]]></Import>
 		<DataSet>
 			<Id>1723103882845</Id>
 			<Name><![CDATA[data_annualPVGeneration_kW]]></Name>
-			<X>392.66666666666663</X>
-			<Y>2105.333333333333</Y>
+			<X>392.667</X>
+			<Y>2115.333</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -672,8 +672,8 @@ import java.util.EnumSet;]]></Import>
 		<DataSet>
 			<Id>1723103882880</Id>
 			<Name><![CDATA[data_annualBatteriesSupply_kW]]></Name>
-			<X>392.66666666666663</X>
-			<Y>2145.333333333333</Y>
+			<X>392.667</X>
+			<Y>2155.333</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -834,8 +834,8 @@ import java.util.EnumSet;]]></Import>
 			<Id>1723103882930</Id>
 			<Name><![CDATA[data_annualNaturalGasSupply_kW]]></Name>
 			<ExcludeFromBuild>true</ExcludeFromBuild>
-			<X>392.66666666666663</X>
-			<Y>2185.333333333333</Y>
+			<X>392.667</X>
+			<Y>2195.333</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -861,8 +861,8 @@ import java.util.EnumSet;]]></Import>
 			<Id>1723103882937</Id>
 			<Name><![CDATA[data_annualDistrictHeatSupply_MWh]]></Name>
 			<ExcludeFromBuild>true</ExcludeFromBuild>
-			<X>392.66666666666663</X>
-			<Y>2225.333333333333</Y>
+			<X>392.667</X>
+			<Y>2235.333</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -915,8 +915,8 @@ import java.util.EnumSet;]]></Import>
 			<Id>1723103882953</Id>
 			<Name><![CDATA[data_annualHydrogenSupply_kW]]></Name>
 			<ExcludeFromBuild>true</ExcludeFromBuild>
-			<X>392.66666666666663</X>
-			<Y>2205.333333333333</Y>
+			<X>392.667</X>
+			<Y>2215.333</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -1603,6 +1603,112 @@ import java.util.EnumSet;]]></Import>
 			<ExcludeFromBuild>true</ExcludeFromBuild>
 			<X>391</X>
 			<Y>2858</Y>
+			<Label>
+				<X>15</X>
+				<Y>0</Y>
+			</Label>
+			<PublicFlag>false</PublicFlag>
+			<PresentationFlag>true</PresentationFlag>
+			<ShowLabel>true</ShowLabel>
+			<AutoUpdate>false</AutoUpdate>
+			<OccurrenceAtTime>true</OccurrenceAtTime>
+			<OccurrenceDate>1687075200000</OccurrenceDate>
+			<OccurrenceTime Class="CodeUnitValue">
+				<Code><![CDATA[0]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</OccurrenceTime>
+			<RecurrenceCode Class="CodeUnitValue">
+				<Code><![CDATA[1]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</RecurrenceCode>
+			<FreezeXAxis>false</FreezeXAxis>
+			<SamplesToKeep>672</SamplesToKeep>
+		</DataSet>
+		<DataSet>
+			<Id>1736518694619</Id>
+			<Name><![CDATA[data_cookingElectricityDemand_kW]]></Name>
+			<X>60</X>
+			<Y>1570</Y>
+			<Label>
+				<X>15</X>
+				<Y>0</Y>
+			</Label>
+			<PublicFlag>false</PublicFlag>
+			<PresentationFlag>true</PresentationFlag>
+			<ShowLabel>true</ShowLabel>
+			<AutoUpdate>false</AutoUpdate>
+			<OccurrenceAtTime>true</OccurrenceAtTime>
+			<OccurrenceDate>1687075200000</OccurrenceDate>
+			<OccurrenceTime Class="CodeUnitValue">
+				<Code><![CDATA[0]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</OccurrenceTime>
+			<RecurrenceCode Class="CodeUnitValue">
+				<Code><![CDATA[1]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</RecurrenceCode>
+			<FreezeXAxis>false</FreezeXAxis>
+			<HorizontalAxisExpression>energyModel.t_h-energyModel.p_runStartTime_h</HorizontalAxisExpression>
+			<VerticalAxisExpression>v_electricHobConsumption_kW</VerticalAxisExpression>
+			<SamplesToKeep>672</SamplesToKeep>
+		</DataSet>
+		<DataSet>
+			<Id>1736518845396</Id>
+			<Name><![CDATA[data_annualCookingElectricityDemand_kW]]></Name>
+			<X>393</X>
+			<Y>2084</Y>
+			<Label>
+				<X>15</X>
+				<Y>0</Y>
+			</Label>
+			<PublicFlag>false</PublicFlag>
+			<PresentationFlag>true</PresentationFlag>
+			<ShowLabel>true</ShowLabel>
+			<AutoUpdate>false</AutoUpdate>
+			<OccurrenceAtTime>true</OccurrenceAtTime>
+			<OccurrenceDate>1687075200000</OccurrenceDate>
+			<OccurrenceTime Class="CodeUnitValue">
+				<Code><![CDATA[0]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</OccurrenceTime>
+			<RecurrenceCode Class="CodeUnitValue">
+				<Code><![CDATA[1]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</RecurrenceCode>
+			<FreezeXAxis>false</FreezeXAxis>
+			<SamplesToKeep>365</SamplesToKeep>
+		</DataSet>
+		<DataSet>
+			<Id>1736518921685</Id>
+			<Name><![CDATA[data_summerWeekCookingElectricityDemand_kW]]></Name>
+			<X>391</X>
+			<Y>2417</Y>
+			<Label>
+				<X>15</X>
+				<Y>0</Y>
+			</Label>
+			<PublicFlag>false</PublicFlag>
+			<PresentationFlag>true</PresentationFlag>
+			<ShowLabel>true</ShowLabel>
+			<AutoUpdate>false</AutoUpdate>
+			<OccurrenceAtTime>true</OccurrenceAtTime>
+			<OccurrenceDate>1687075200000</OccurrenceDate>
+			<OccurrenceTime Class="CodeUnitValue">
+				<Code><![CDATA[0]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</OccurrenceTime>
+			<RecurrenceCode Class="CodeUnitValue">
+				<Code><![CDATA[1]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</RecurrenceCode>
+			<FreezeXAxis>false</FreezeXAxis>
+			<SamplesToKeep>672</SamplesToKeep>
+		</DataSet>
+		<DataSet>
+			<Id>1736518998850</Id>
+			<Name><![CDATA[data_winterWeekCookingElectricityDemand_kW]]></Name>
+			<X>390</X>
+			<Y>2727</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>

--- a/_alp/Agents/EnergyCoop/Code/Functions.java
+++ b/_alp/Agents/EnergyCoop/Code/Functions.java
@@ -1091,7 +1091,7 @@ v_dailyBaseloadElectricityDemand_kW = 0;
 v_dailyHeatPumpElectricityDemand_kW = 0;
 v_dailyElectricVehicleDemand_kW = 0;
 v_dailyBatteriesDemand_kW = 0;
-
+v_dailyCookingElectricityDemand_kW = 0;
 
 // Supply
 fm_dailyAverageSupply_kW.clear();
@@ -1315,6 +1315,7 @@ if (energyModel.v_isRapidRun){
 	data_heatPumpElectricityDemand_kW.update();
 	data_electricVehicleDemand_kW.update();
 	data_batteryCharging_kW.update();
+	data_cookingElectricityDemand_kW.update();
 	
 	data_PVGeneration_kW.update();
 	data_V2GSupply_kW.update();
@@ -1771,6 +1772,7 @@ if (energyModel.t_h >= energyModel.p_startHourSummerWeek && energyModel.t_h < en
 	data_summerWeekHeatPumpElectricityDemand_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, v_heatPumpElectricityConsumption_kW);
 	data_summerWeekElectricVehicleDemand_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, max(0,v_evChargingPowerElectric_kW));
 	data_summerWeekBatteriesDemand_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, max(0,v_batteryPowerElectric_kW));
+	data_summerWeekCookingElectricityDemand_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, v_electricHobConsumption_kW);
 	
 	data_summerWeekPVGeneration_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, v_pvProductionElectric_kW);
 	data_summerWeekWindGeneration_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, v_windProductionElectric_kW);
@@ -1790,6 +1792,7 @@ if (energyModel.t_h >= energyModel.p_startHourWinterWeek && energyModel.t_h < en
 	data_winterWeekHeatPumpElectricityDemand_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, v_heatPumpElectricityConsumption_kW);
 	data_winterWeekElectricVehicleDemand_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, max(0, v_evChargingPowerElectric_kW));
 	data_winterWeekBatteriesDemand_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, max(0, v_batteryPowerElectric_kW));
+	data_winterWeekCookingElectricityDemand_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, v_electricHobConsumption_kW);
 	
 	data_winterWeekPVGeneration_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, v_pvProductionElectric_kW);
 	data_winterWeekWindGeneration_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, v_windProductionElectric_kW);
@@ -1805,6 +1808,7 @@ v_dailyBaseloadElectricityDemand_kW += v_fixedConsumptionElectric_kW;
 v_dailyHeatPumpElectricityDemand_kW += v_heatPumpElectricityConsumption_kW;
 v_dailyElectricVehicleDemand_kW += max(0,v_evChargingPowerElectric_kW);
 v_dailyBatteriesDemand_kW += max(0,v_batteryPowerElectric_kW);
+v_dailyCookingElectricityDemand_kW += v_electricHobConsumption_kW;
 
 // Supply
 fm_dailyAverageSupply_kW.addFlows(fm_currentProductionFlows_kW);
@@ -1825,6 +1829,7 @@ if (energyModel.t_h % 24 == 24-energyModel.p_timeStep_h) {
 	data_annualHeatPumpElectricityDemand_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, v_dailyHeatPumpElectricityDemand_kW/(24 / energyModel.p_timeStep_h));
 	data_annualElectricVehicleDemand_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, v_dailyElectricVehicleDemand_kW/(24 / energyModel.p_timeStep_h));
 	data_annualBatteriesDemand_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, v_dailyBatteriesDemand_kW/(24 / energyModel.p_timeStep_h));
+	data_annualCookingElectricityDemand_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, v_dailyCookingElectricityDemand_kW/(24 / energyModel.p_timeStep_h));
 	// Supply
 	data_annualPVGeneration_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, v_dailyPVGeneration_kW/(24 / energyModel.p_timeStep_h));
 	data_annualWindGeneration_kW.add(energyModel.t_h-energyModel.p_runStartTime_h, v_dailyWindGeneration_kW/(24 / energyModel.p_timeStep_h));
@@ -1838,6 +1843,7 @@ if (energyModel.t_h % 24 == 24-energyModel.p_timeStep_h) {
 	v_dailyHeatPumpElectricityDemand_kW = 0;
 	v_dailyElectricVehicleDemand_kW = 0;
 	v_dailyBatteriesDemand_kW = 0;
+	v_dailyCookingElectricityDemand_kW = 0;
 	// Supply
 	fm_dailyAverageSupply_kW.clear();
 	v_dailyPVGeneration_kW = 0;

--- a/_alp/Agents/EnergyCoop/Variables.xml
+++ b/_alp/Agents/EnergyCoop/Variables.xml
@@ -1456,8 +1456,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1723103882807</Id>
 		<Name><![CDATA[v_dailyPVGeneration_kW]]></Name>
-		<X>62.66666666666663</X>
-		<Y>2105.333333333333</Y>
+		<X>62.667</X>
+		<Y>2115.333</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1475,8 +1475,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1723103882809</Id>
 		<Name><![CDATA[v_dailyWindGeneration_kW]]></Name>
-		<X>62.66666666666663</X>
-		<Y>2125.333333333333</Y>
+		<X>62.667</X>
+		<Y>2135.333</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1494,8 +1494,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1723103882811</Id>
 		<Name><![CDATA[v_dailyBatteriesSupply_kW]]></Name>
-		<X>62.66666666666663</X>
-		<Y>2145.333333333333</Y>
+		<X>62.667</X>
+		<Y>2155.333</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1513,8 +1513,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1723103882813</Id>
 		<Name><![CDATA[v_dailyV2GSupply_kW]]></Name>
-		<X>62.66666666666663</X>
-		<Y>2165.333333333333</Y>
+		<X>62.667</X>
+		<Y>2175.333</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1653,8 +1653,8 @@
 		<Id>1723103882827</Id>
 		<Name><![CDATA[v_dailyDistrictHeatSupply_kWh]]></Name>
 		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>62.66666666666663</X>
-		<Y>2225.333333333333</Y>
+		<X>62.667</X>
+		<Y>2235.333</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1673,8 +1673,8 @@
 		<Id>1723103882829</Id>
 		<Name><![CDATA[v_dailyNaturalGasSupply_kW]]></Name>
 		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>62.66666666666663</X>
-		<Y>2185.333333333333</Y>
+		<X>62.667</X>
+		<Y>2195.333</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1693,8 +1693,8 @@
 		<Id>1723103882831</Id>
 		<Name><![CDATA[v_dailyHydrogenSupply_kW]]></Name>
 		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>62.66666666666663</X>
-		<Y>2205.333333333333</Y>
+		<X>62.667</X>
+		<Y>2215.333</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -4240,6 +4240,25 @@
 			<InitialValue Class="CodeValue">
 				<Code><![CDATA[EnumSet.of(OL_EnergyCarriers.ELECTRICITY);]]></Code>
 			</InitialValue>
+		</Properties>
+	</Variable>
+	<Variable Class="PlainVariable">
+		<Id>1736518845393</Id>
+		<Name><![CDATA[v_dailyCookingElectricityDemand_kW]]></Name>
+		<X>63</X>
+		<Y>2084</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Properties SaveInSnapshot="true"
+              Constant="false"
+              AccessType="public"
+              StaticVariable="false">
+			<Type><![CDATA[double]]></Type>
 		</Properties>
 	</Variable>
 	<Variable Class="Parameter">

--- a/_alp/Agents/EnergyModel/AOC.EnergyModel.xml
+++ b/_alp/Agents/EnergyModel/AOC.EnergyModel.xml
@@ -1080,7 +1080,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1715246336413</Id>
 			<Name><![CDATA[data_annualWindGeneration_kW]]></Name>
 			<X>390</X>
-			<Y>3060</Y>
+			<Y>3100</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -1106,7 +1106,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1715246336419</Id>
 			<Name><![CDATA[data_annualV2GSupply_kW]]></Name>
 			<X>390</X>
-			<Y>3100</Y>
+			<Y>3140</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -1132,7 +1132,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1715246336425</Id>
 			<Name><![CDATA[data_annualPVGeneration_kW]]></Name>
 			<X>390</X>
-			<Y>3040</Y>
+			<Y>3080</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -1236,7 +1236,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1715246336451</Id>
 			<Name><![CDATA[data_annualBatteriesSupply_kW]]></Name>
 			<X>390</X>
-			<Y>3080</Y>
+			<Y>3120</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -1344,7 +1344,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Name><![CDATA[data_annualNaturalGasSupply_kW]]></Name>
 			<ExcludeFromBuild>true</ExcludeFromBuild>
 			<X>390</X>
-			<Y>3120</Y>
+			<Y>3160</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -1371,7 +1371,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Name><![CDATA[data_annualDistrictHeatSupply_MWh]]></Name>
 			<ExcludeFromBuild>true</ExcludeFromBuild>
 			<X>390</X>
-			<Y>3160</Y>
+			<Y>3200</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -1450,7 +1450,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1715246378188</Id>
 			<Name><![CDATA[data_summerWeekWindGeneration_kW]]></Name>
 			<X>830</X>
-			<Y>3030</Y>
+			<Y>3070</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -1476,7 +1476,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1715246378194</Id>
 			<Name><![CDATA[data_summerWeekV2GSupply_kW]]></Name>
 			<X>830</X>
-			<Y>3070</Y>
+			<Y>3110</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -1502,7 +1502,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1715246378199</Id>
 			<Name><![CDATA[data_summerWeekPVGeneration_kW]]></Name>
 			<X>830</X>
-			<Y>3010</Y>
+			<Y>3050</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -1606,7 +1606,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1715246378219</Id>
 			<Name><![CDATA[data_summerWeekBatteriesSupply_kW]]></Name>
 			<X>830</X>
-			<Y>3050</Y>
+			<Y>3090</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -1713,7 +1713,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1715246378239</Id>
 			<Name><![CDATA[data_summerWeekNaturalGasSupply_kW]]></Name>
 			<X>830</X>
-			<Y>3090</Y>
+			<Y>3130</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -1765,7 +1765,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1715246378248</Id>
 			<Name><![CDATA[data_winterWeekWindGeneration_kW]]></Name>
 			<X>1280</X>
-			<Y>3030</Y>
+			<Y>3070</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -1791,7 +1791,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1715246378254</Id>
 			<Name><![CDATA[data_winterWeekV2GSupply_kW]]></Name>
 			<X>1280</X>
-			<Y>3070</Y>
+			<Y>3110</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -1817,7 +1817,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1715246378259</Id>
 			<Name><![CDATA[data_winterWeekPVGeneration_kW]]></Name>
 			<X>1280</X>
-			<Y>3010</Y>
+			<Y>3050</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -1921,7 +1921,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1715246378279</Id>
 			<Name><![CDATA[data_winterWeekBatteriesSupply_kW]]></Name>
 			<X>1280</X>
-			<Y>3050</Y>
+			<Y>3090</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -2029,7 +2029,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Name><![CDATA[data_winterWeekNaturalGasSupply_kW]]></Name>
 			<ExcludeFromBuild>true</ExcludeFromBuild>
 			<X>1280</X>
-			<Y>3090</Y>
+			<Y>3130</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -2056,7 +2056,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Name><![CDATA[data_annualHydrogenSupply_kW]]></Name>
 			<ExcludeFromBuild>true</ExcludeFromBuild>
 			<X>390</X>
-			<Y>3140</Y>
+			<Y>3180</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -2083,7 +2083,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Name><![CDATA[data_winterWeekHydrogenSupply_kW]]></Name>
 			<ExcludeFromBuild>true</ExcludeFromBuild>
 			<X>1280</X>
-			<Y>3110</Y>
+			<Y>3150</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -2110,7 +2110,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Name><![CDATA[data_summerWeekHydrogenSupply_kW]]></Name>
 			<ExcludeFromBuild>true</ExcludeFromBuild>
 			<X>830</X>
-			<Y>3110</Y>
+			<Y>3150</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -2277,7 +2277,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1721134096132</Id>
 			<Name><![CDATA[data_summerWeekNetLoad_kW]]></Name>
 			<X>830</X>
-			<Y>3165</Y>
+			<Y>3205</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -2303,7 +2303,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1721134140759</Id>
 			<Name><![CDATA[data_winterWeekNetLoad_kW]]></Name>
 			<X>1280</X>
-			<Y>3160</Y>
+			<Y>3200</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -2489,7 +2489,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1734092249487</Id>
 			<Name><![CDATA[data_annualCHPElectricityProduction_kW]]></Name>
 			<X>390</X>
-			<Y>3180</Y>
+			<Y>3220</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -2515,7 +2515,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1734092276192</Id>
 			<Name><![CDATA[data_summerWeekCHPElectricityProduction_kW]]></Name>
 			<X>830</X>
-			<Y>3130</Y>
+			<Y>3170</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -2541,7 +2541,7 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<Id>1734092294449</Id>
 			<Name><![CDATA[data_winterWeekCHPElectricityProduction_kW]]></Name>
 			<X>1280</X>
-			<Y>3130</Y>
+			<Y>3170</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -2589,6 +2589,84 @@ import zeroPackage.ZeroAccumulator;]]></Import>
 			<FreezeXAxis>false</FreezeXAxis>
 			<HorizontalAxisExpression>t_h-p_runStartTime_h</HorizontalAxisExpression>
 			<VerticalAxisExpression>sum(c_gridConnections,x-&gt;x.v_CHPProductionElectric_kW)</VerticalAxisExpression>
+			<SamplesToKeep>672</SamplesToKeep>
+		</DataSet>
+		<DataSet>
+			<Id>1736432989842</Id>
+			<Name><![CDATA[data_annualCookingElectricityDemand_kW]]></Name>
+			<X>390</X>
+			<Y>3030</Y>
+			<Label>
+				<X>15</X>
+				<Y>0</Y>
+			</Label>
+			<PublicFlag>false</PublicFlag>
+			<PresentationFlag>true</PresentationFlag>
+			<ShowLabel>true</ShowLabel>
+			<AutoUpdate>false</AutoUpdate>
+			<OccurrenceAtTime>true</OccurrenceAtTime>
+			<OccurrenceDate>1687075200000</OccurrenceDate>
+			<OccurrenceTime Class="CodeUnitValue">
+				<Code><![CDATA[0]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</OccurrenceTime>
+			<RecurrenceCode Class="CodeUnitValue">
+				<Code><![CDATA[1]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</RecurrenceCode>
+			<FreezeXAxis>false</FreezeXAxis>
+			<SamplesToKeep>365</SamplesToKeep>
+		</DataSet>
+		<DataSet>
+			<Id>1736432989848</Id>
+			<Name><![CDATA[data_summerWeekCookingElectricityDemand_kW]]></Name>
+			<X>830</X>
+			<Y>2990</Y>
+			<Label>
+				<X>15</X>
+				<Y>0</Y>
+			</Label>
+			<PublicFlag>false</PublicFlag>
+			<PresentationFlag>true</PresentationFlag>
+			<ShowLabel>true</ShowLabel>
+			<AutoUpdate>false</AutoUpdate>
+			<OccurrenceAtTime>true</OccurrenceAtTime>
+			<OccurrenceDate>1687075200000</OccurrenceDate>
+			<OccurrenceTime Class="CodeUnitValue">
+				<Code><![CDATA[0]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</OccurrenceTime>
+			<RecurrenceCode Class="CodeUnitValue">
+				<Code><![CDATA[1]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</RecurrenceCode>
+			<FreezeXAxis>false</FreezeXAxis>
+			<SamplesToKeep>672</SamplesToKeep>
+		</DataSet>
+		<DataSet>
+			<Id>1736432989854</Id>
+			<Name><![CDATA[data_winterWeekCookingElectricityDemand_kW]]></Name>
+			<X>1280</X>
+			<Y>2990</Y>
+			<Label>
+				<X>15</X>
+				<Y>0</Y>
+			</Label>
+			<PublicFlag>false</PublicFlag>
+			<PresentationFlag>true</PresentationFlag>
+			<ShowLabel>true</ShowLabel>
+			<AutoUpdate>false</AutoUpdate>
+			<OccurrenceAtTime>true</OccurrenceAtTime>
+			<OccurrenceDate>1687075200000</OccurrenceDate>
+			<OccurrenceTime Class="CodeUnitValue">
+				<Code><![CDATA[0]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</OccurrenceTime>
+			<RecurrenceCode Class="CodeUnitValue">
+				<Code><![CDATA[1]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</RecurrenceCode>
+			<FreezeXAxis>false</FreezeXAxis>
 			<SamplesToKeep>672</SamplesToKeep>
 		</DataSet>
 	</AnalysisData>

--- a/_alp/Agents/EnergyModel/Variables.xml
+++ b/_alp/Agents/EnergyModel/Variables.xml
@@ -2108,7 +2108,7 @@
 		<Id>1715246315939</Id>
 		<Name><![CDATA[v_dailyPVGeneration_kW]]></Name>
 		<X>20</X>
-		<Y>3040</Y>
+		<Y>3080</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2127,7 +2127,7 @@
 		<Id>1715246315941</Id>
 		<Name><![CDATA[v_dailyWindGeneration_kW]]></Name>
 		<X>20</X>
-		<Y>3060</Y>
+		<Y>3100</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2146,7 +2146,7 @@
 		<Id>1715246315943</Id>
 		<Name><![CDATA[v_dailyBatteriesSupply_kW]]></Name>
 		<X>20</X>
-		<Y>3080</Y>
+		<Y>3120</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2165,7 +2165,7 @@
 		<Id>1715246315945</Id>
 		<Name><![CDATA[v_dailyV2GSupply_kW]]></Name>
 		<X>20</X>
-		<Y>3100</Y>
+		<Y>3140</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2265,7 +2265,7 @@
 		<Name><![CDATA[v_dailyDistrictHeatSupply_kWh]]></Name>
 		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>20</X>
-		<Y>3160</Y>
+		<Y>3200</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2285,7 +2285,7 @@
 		<Name><![CDATA[v_dailyNaturalGasSupply_kW]]></Name>
 		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>20</X>
-		<Y>3120</Y>
+		<Y>3160</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2305,7 +2305,7 @@
 		<Name><![CDATA[v_dailyHydrogenSupply_kW]]></Name>
 		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>20</X>
-		<Y>3140</Y>
+		<Y>3180</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -4157,7 +4157,7 @@
 		<Id>1730968866329</Id>
 		<Name><![CDATA[fm_dailyAverageDemand_kW]]></Name>
 		<X>20</X>
-		<Y>3220</Y>
+		<Y>3260</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -4179,7 +4179,7 @@
 		<Id>1730968866331</Id>
 		<Name><![CDATA[fm_dailyAverageSupply_kW]]></Name>
 		<X>20</X>
-		<Y>3240</Y>
+		<Y>3280</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -4201,7 +4201,7 @@
 		<Id>1730968866333</Id>
 		<Name><![CDATA[dsm_dailyAverageDemandDataSets_kW]]></Name>
 		<X>390</X>
-		<Y>3220</Y>
+		<Y>3260</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -4223,7 +4223,7 @@
 		<Id>1730968866335</Id>
 		<Name><![CDATA[dsm_dailyAverageSupplyDataSets_kW]]></Name>
 		<X>390</X>
-		<Y>3240</Y>
+		<Y>3280</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -4245,7 +4245,7 @@
 		<Id>1730968880670</Id>
 		<Name><![CDATA[dsm_summerWeekDemandDataSets_kW]]></Name>
 		<X>830</X>
-		<Y>3205</Y>
+		<Y>3245</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -4267,7 +4267,7 @@
 		<Id>1730968880672</Id>
 		<Name><![CDATA[dsm_summerWeekSupplyDataSets_kW]]></Name>
 		<X>830</X>
-		<Y>3225</Y>
+		<Y>3265</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -4289,7 +4289,7 @@
 		<Id>1730968880674</Id>
 		<Name><![CDATA[dsm_winterWeekDemandDataSets_kW]]></Name>
 		<X>1280</X>
-		<Y>3200</Y>
+		<Y>3240</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -4311,7 +4311,7 @@
 		<Id>1730968880676</Id>
 		<Name><![CDATA[dsm_winterWeekSupplyDataSets_kW]]></Name>
 		<X>1280</X>
-		<Y>3220</Y>
+		<Y>3260</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -4910,7 +4910,26 @@
 		<Id>1734092339930</Id>
 		<Name><![CDATA[v_dailyCHPElectricityProduction_kW]]></Name>
 		<X>20</X>
-		<Y>3180</Y>
+		<Y>3220</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Properties SaveInSnapshot="true"
+              Constant="false"
+              AccessType="public"
+              StaticVariable="false">
+			<Type><![CDATA[double]]></Type>
+		</Properties>
+	</Variable>
+	<Variable Class="PlainVariable">
+		<Id>1736432989839</Id>
+		<Name><![CDATA[v_dailyAverageCookingElectricityDemand_kW]]></Name>
+		<X>20</X>
+		<Y>3030</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>

--- a/_alp/Agents/GridConnection/AOC.GridConnection.xml
+++ b/_alp/Agents/GridConnection/AOC.GridConnection.xml
@@ -2057,7 +2057,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 		</DataSet>
 		<DataSet>
 			<Id>1726222586985</Id>
-			<Name><![CDATA[data_electricHobDemand_kW]]></Name>
+			<Name><![CDATA[data_cookingElectricityDemand_kW]]></Name>
 			<X>150</X>
 			<Y>2180</Y>
 			<Label>
@@ -2169,7 +2169,7 @@ import javax.management.RuntimeErrorException;]]></Import>
 			<Id>1734091175218</Id>
 			<Name><![CDATA[data_winterWeekCHPElectricityProduction_kW]]></Name>
 			<X>1490</X>
-			<Y>2620</Y>
+			<Y>2780</Y>
 			<Label>
 				<X>15</X>
 				<Y>0</Y>
@@ -2216,6 +2216,84 @@ import javax.management.RuntimeErrorException;]]></Import>
 			</RecurrenceCode>
 			<FreezeXAxis>false</FreezeXAxis>
 			<SamplesToKeep>365</SamplesToKeep>
+		</DataSet>
+		<DataSet>
+			<Id>1736433078739</Id>
+			<Name><![CDATA[data_annualCookingElectricityDemand_kW]]></Name>
+			<X>1070</X>
+			<Y>2470</Y>
+			<Label>
+				<X>15</X>
+				<Y>0</Y>
+			</Label>
+			<PublicFlag>false</PublicFlag>
+			<PresentationFlag>true</PresentationFlag>
+			<ShowLabel>true</ShowLabel>
+			<AutoUpdate>false</AutoUpdate>
+			<OccurrenceAtTime>true</OccurrenceAtTime>
+			<OccurrenceDate>1687075200000</OccurrenceDate>
+			<OccurrenceTime Class="CodeUnitValue">
+				<Code><![CDATA[0]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</OccurrenceTime>
+			<RecurrenceCode Class="CodeUnitValue">
+				<Code><![CDATA[1]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</RecurrenceCode>
+			<FreezeXAxis>false</FreezeXAxis>
+			<SamplesToKeep>365</SamplesToKeep>
+		</DataSet>
+		<DataSet>
+			<Id>1736433078745</Id>
+			<Name><![CDATA[data_summerWeekCookingElectricityDemand_kW]]></Name>
+			<X>1490</X>
+			<Y>2280</Y>
+			<Label>
+				<X>15</X>
+				<Y>0</Y>
+			</Label>
+			<PublicFlag>false</PublicFlag>
+			<PresentationFlag>true</PresentationFlag>
+			<ShowLabel>true</ShowLabel>
+			<AutoUpdate>false</AutoUpdate>
+			<OccurrenceAtTime>true</OccurrenceAtTime>
+			<OccurrenceDate>1687075200000</OccurrenceDate>
+			<OccurrenceTime Class="CodeUnitValue">
+				<Code><![CDATA[0]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</OccurrenceTime>
+			<RecurrenceCode Class="CodeUnitValue">
+				<Code><![CDATA[1]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</RecurrenceCode>
+			<FreezeXAxis>false</FreezeXAxis>
+			<SamplesToKeep>672</SamplesToKeep>
+		</DataSet>
+		<DataSet>
+			<Id>1736433078749</Id>
+			<Name><![CDATA[data_winterWeekCookingElectricityDemand_kW]]></Name>
+			<X>1490</X>
+			<Y>2620</Y>
+			<Label>
+				<X>15</X>
+				<Y>0</Y>
+			</Label>
+			<PublicFlag>false</PublicFlag>
+			<PresentationFlag>true</PresentationFlag>
+			<ShowLabel>true</ShowLabel>
+			<AutoUpdate>false</AutoUpdate>
+			<OccurrenceAtTime>true</OccurrenceAtTime>
+			<OccurrenceDate>1687075200000</OccurrenceDate>
+			<OccurrenceTime Class="CodeUnitValue">
+				<Code><![CDATA[0]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</OccurrenceTime>
+			<RecurrenceCode Class="CodeUnitValue">
+				<Code><![CDATA[1]]></Code>
+				<Unit Class="TimeUnits">HOUR</Unit>
+			</RecurrenceCode>
+			<FreezeXAxis>false</FreezeXAxis>
+			<SamplesToKeep>672</SamplesToKeep>
 		</DataSet>
 	</AnalysisData>
 	<AgentLinks>

--- a/_alp/Agents/GridConnection/Code/Functions.java
+++ b/_alp/Agents/GridConnection/Code/Functions.java
@@ -2149,7 +2149,7 @@ v_electricHobConsumption_kW = 0;
 for (J_EA j_ea : c_electricHobAssets) {
 	v_electricHobConsumption_kW += j_ea.getLastFlows().get(OL_EnergyCarriers.ELECTRICITY);
 }
-data_electricHobDemand_kW.update();
+data_cookingElectricityDemand_kW.update();
 
 v_hydrogenElectricityConsumption_kW = 0;
 for (J_EA j_ea : c_electrolyserAssets) {
@@ -2338,6 +2338,7 @@ if (energyModel.b_isSummerWeek){
 	data_summerWeekHeatPumpElectricityDemand_kW.add(energyModel.t_h, v_heatPumpElectricityConsumption_kW);
 	data_summerWeekElectricVehicleDemand_kW.add(energyModel.t_h, max(0,v_evChargingPowerElectric_kW));
 	data_summerWeekBatteriesDemand_kW.add(energyModel.t_h, max(0,v_batteryPowerElectric_kW));
+	data_summerWeekCookingElectricityDemand_kW.add(energyModel.t_h, v_electricHobConsumption_kW);
 	
 	data_summerWeekPVGeneration_kW.add(energyModel.t_h, v_pvProductionElectric_kW);
 	data_summerWeekWindGeneration_kW.add(energyModel.t_h, v_windProductionElectric_kW);
@@ -2370,6 +2371,7 @@ if (energyModel.b_isWinterWeek){
 	data_winterWeekHeatPumpElectricityDemand_kW.add(energyModel.t_h, v_heatPumpElectricityConsumption_kW);
 	data_winterWeekElectricVehicleDemand_kW.add(energyModel.t_h, max(0, v_evChargingPowerElectric_kW));
 	data_winterWeekBatteriesDemand_kW.add(energyModel.t_h, max(0, v_batteryPowerElectric_kW));
+	data_winterWeekCookingElectricityDemand_kW.add(energyModel.t_h, v_electricHobConsumption_kW);
 	
 	data_winterWeekPVGeneration_kW.add(energyModel.t_h, v_pvProductionElectric_kW);
 	data_winterWeekWindGeneration_kW.add(energyModel.t_h, v_windProductionElectric_kW);
@@ -2386,6 +2388,7 @@ v_dailyBaseloadElectricityDemand_kW += v_fixedConsumptionElectric_kW;
 v_dailyHeatPumpElectricityDemand_kW += v_heatPumpElectricityConsumption_kW;
 v_dailyElectricVehicleDemand_kW += max(0,v_evChargingPowerElectric_kW);
 v_dailyBatteriesDemand_kW += max(0,v_batteryPowerElectric_kW);
+v_dailyCookingElectricityDemand_kW += v_electricHobConsumption_kW;
 
 // Supply
 fm_dailyAverageSupply_kW.addFlows(fm_currentProductionFlows_kW);
@@ -2407,6 +2410,7 @@ if (energyModel.b_isLastTimeStepOfDay) {
 	data_annualHeatPumpElectricityDemand_kW.add(energyModel.t_h, v_dailyHeatPumpElectricityDemand_kW/ timeStepsInOneDay);
 	data_annualElectricVehicleDemand_kW.add(energyModel.t_h, v_dailyElectricVehicleDemand_kW/ timeStepsInOneDay);
 	data_annualBatteriesDemand_kW.add(energyModel.t_h, v_dailyBatteriesDemand_kW/ timeStepsInOneDay);
+	data_annualCookingElectricityDemand_kW.add(energyModel.t_h, v_dailyCookingElectricityDemand_kW/ timeStepsInOneDay);
 	
 	// Supply
 	data_annualPVGeneration_kW.add(energyModel.t_h, v_dailyPVGeneration_kW/ timeStepsInOneDay);
@@ -2426,6 +2430,7 @@ if (energyModel.b_isLastTimeStepOfDay) {
 	v_dailyHeatPumpElectricityDemand_kW = 0;
 	v_dailyElectricVehicleDemand_kW = 0;
 	v_dailyBatteriesDemand_kW = 0;
+	v_dailyCookingElectricityDemand_kW = 0;
 	
 	// Supply
 	fm_dailyAverageSupply_kW.clear();

--- a/_alp/Agents/GridConnection/Variables.xml
+++ b/_alp/Agents/GridConnection/Variables.xml
@@ -4798,6 +4798,25 @@
 			<Type><![CDATA[double]]></Type>
 		</Properties>
 	</Variable>
+	<Variable Class="PlainVariable">
+		<Id>1736433078736</Id>
+		<Name><![CDATA[v_dailyCookingElectricityDemand_kW]]></Name>
+		<X>740</X>
+		<Y>2470</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Properties SaveInSnapshot="true"
+              Constant="false"
+              AccessType="public"
+              StaticVariable="false">
+			<Type><![CDATA[double]]></Type>
+		</Properties>
+	</Variable>
 	<Variable Class="Parameter">
 		<Id>1658499438204</Id>
 		<Name><![CDATA[p_gridConnectionCategory]]></Name>

--- a/_alp/Classes/Class.J_ActivityTracker.java
+++ b/_alp/Classes/Class.J_ActivityTracker.java
@@ -10,7 +10,7 @@ public class J_ActivityTracker implements Serializable {
 	//private ArrayList<Double> eventMagnitude = new ArrayList<>();
     public int nbActivities = 0;
 	public int v_eventIndex = 0;
-	private int v_eventIndexStored =0;
+	protected int v_eventIndexStored =0;
 
 	
     /**
@@ -43,4 +43,4 @@ public class J_ActivityTracker implements Serializable {
 	 */ 
 	private static final long serialVersionUID = 1L;
 
-}
+} 

--- a/_alp/Classes/Class.J_ActivityTrackerCooking.java
+++ b/_alp/Classes/Class.J_ActivityTrackerCooking.java
@@ -7,7 +7,13 @@ public class J_ActivityTrackerCooking extends zero_engine.J_ActivityTracker impl
 	public double powerFraction_fr=0;
 	private int rowIndex;
 	private boolean cooking = false;
-    /**
+	private double timeStep_min;
+	private ArrayList<Double> initalStarttimes_min;
+	private ArrayList<Double> initalEndtimes_min;
+	private ArrayList<Double> storedStarttimes_min;
+	private ArrayList<Double> storedEndtimes_min;
+
+	/**
      * Default constructor
      */
     public J_ActivityTrackerCooking() {
@@ -17,8 +23,12 @@ public class J_ActivityTrackerCooking extends zero_engine.J_ActivityTracker impl
     	//this.energyModel = main;
     	this.rowIndex = rowIndex;
     	this.HOB=HOB;
-    	
     	//int rowIndex = uniform_discr(2, 300); 
+    	//traceln("RowIndex: %s", this.rowIndex);
+    	//traceln(this.HOB.getParentAgent());
+    	
+    	this.timeStep_min = 60 * this.HOB.timestep_h;
+    	
     	double v_cookingPatternIndex = inputCookingActivities.getCellNumericValue("sheet1", rowIndex, 1);
     	int nbOfCookingSessions = (int)(inputCookingActivities.getCellNumericValue("sheet1", rowIndex, 2));
 
@@ -38,18 +48,30 @@ public class J_ActivityTrackerCooking extends zero_engine.J_ActivityTracker impl
     			v_eventIndex = 0;
     		}
     	}
-
+    	
+    	
+    	initalStarttimes_min = new ArrayList<>(starttimes_min);
+    	initalEndtimes_min = new ArrayList<>(endtimes_min);
     	//traceln("Current model time in minutes: " + energyModel.t_h*60 + ", nb sessions: " + nbOfCookingSessions);
+    	//traceln("Starttimes: %s", starttimes_min);
+    	//traceln("Endtimes: %s", endtimes_min);
     }
     
     public void manageActivities(double time_min) {
     	//traceln("Cooking tracker current time: " + time_min);
+    	//traceln("Event index: " + v_eventIndex);
+    	//traceln("startTimes: " + starttimes_min);
+    	//traceln("endTimes: " + endtimes_min);
+    	//traceln("powerFractions_fr: "  + powerFractions_fr);
+    	
     	if (cooking) {
 	    	if (time_min >= endtimes_min.get(v_eventIndex) ) { // end cooking session. Also check if a new one starts in this timestep!
 
 	    		//main.v_activeCookingSessions.decrementAndGet();
 	    		//traceln("End of cooking session, currently active cooking sessions %s", main.v_activeCookingSessions);
-	    		powerFraction_fr = 0;
+				// factor to compensate for the fact that you might not be cooking for the entire timestep.
+				double fr = (time_min - this.endtimes_min.get(this.v_eventIndex)) / this.timeStep_min;
+				this.powerFraction_fr = fr * this.powerFractions_fr.get(this.v_eventIndex);
 	    		
 				starttimes_min.set( v_eventIndex, starttimes_min.get(v_eventIndex) + 1440 );
 				endtimes_min.set( v_eventIndex, endtimes_min.get(v_eventIndex) + 1440 );
@@ -60,25 +82,33 @@ public class J_ActivityTrackerCooking extends zero_engine.J_ActivityTracker impl
 				cooking=false;
 				
 				if (time_min >= starttimes_min.get(v_eventIndex)) {
-					powerFraction_fr = powerFractions_fr.get(v_eventIndex);	    		
+					// factor to compensate for the fact that you might not be cooking for the entire timestep.
+					fr = (time_min - this.starttimes_min.get(this.v_eventIndex)) / this.timeStep_min;
+					this.powerFraction_fr = fr * this.powerFractions_fr.get(this.v_eventIndex);	    		
 					//main.v_activeCookingSessions.incrementAndGet();
 					cooking=true;
 					traceln("Starting next cooking session in same timestep as previous session ended!! Rowindex %s, eventIndex %s\", rowIndex, v_eventIndex");
 				}
 	    	}
+	    	else {
+	    		this.powerFraction_fr = this.starttimes_min.get(this.v_eventIndex);
+	    	}
     	} else if (time_min >= starttimes_min.get(v_eventIndex) ) { // start cooking session. Also check if it ends within this timestep!
     		/*if (endtimes_min.get(v_eventIndex) - starttimes_min.get(v_eventIndex) > 100) {
 			traceln("Cooking event longer than 100 minutes!! Rowindex %s, eventIndex %s.", rowIndex, v_eventIndex);
 			}*/
-   		
-			powerFraction_fr = powerFractions_fr.get(v_eventIndex);	    		
+    		
+			// factor to compensate for the fact that you might not be cooking for the entire timestep.
+			double fr = (time_min - this.starttimes_min.get(this.v_eventIndex)) / this.timeStep_min;
+			this.powerFraction_fr = fr * this.powerFractions_fr.get(this.v_eventIndex);	    		
 			//main.v_activeCookingSessions.incrementAndGet();
 			cooking=true;
 			if (time_min >= endtimes_min.get(v_eventIndex) ) { // end cooking session in the same timestep? Still need to fix energy use for this case!! 
 	    	
 	    		//main.v_activeCookingSessions.decrementAndGet();
 	    		//traceln("End of cooking session, currently active cooking sessions %s", main.v_activeCookingSessions);
-	    		powerFraction_fr = 0;
+				fr = (this.endtimes_min.get(this.v_eventIndex) - this.starttimes_min.get(this.v_eventIndex)) / this.timeStep_min;	    		
+				this.powerFraction_fr = fr * this.powerFractions_fr.get(this.v_eventIndex);	    		
 	    		
 				starttimes_min.set( v_eventIndex, starttimes_min.get(v_eventIndex) + 1440 );
 				endtimes_min.set( v_eventIndex, endtimes_min.get(v_eventIndex) + 1440 );
@@ -88,10 +118,30 @@ public class J_ActivityTrackerCooking extends zero_engine.J_ActivityTracker impl
 				}
 				cooking=false;
 			}
-    	} 
+    	}
+    	else {
+    		this.powerFraction_fr = 0;
+    	}
     	//if (powerFraction_fr > 0 ) { traceln("Cooking event in progress!"); }
     	HOB.f_updateAllFlows(powerFraction_fr);
     }
+    
+    @Override
+    public void storeAndResetState() {
+    	v_eventIndexStored = v_eventIndex;
+    	storedStarttimes_min = new ArrayList<>(starttimes_min);
+    	storedEndtimes_min = new ArrayList<>(endtimes_min);    	
+		starttimes_min = new ArrayList<>(initalStarttimes_min);
+		endtimes_min = new ArrayList<>(initalEndtimes_min);
+    	v_eventIndex = 0;
+    }
+    
+    @Override
+    public void restoreState() {
+    	v_eventIndex = v_eventIndexStored;
+		starttimes_min = new ArrayList<>(storedStarttimes_min);
+		endtimes_min = new ArrayList<>(storedEndtimes_min);
+	}
     
     @Override
 	public String toString() {

--- a/_alp/Classes/Class.J_EAElectricHob.java
+++ b/_alp/Classes/Class.J_EAElectricHob.java
@@ -3,43 +3,36 @@
  */	
 public class J_EAElectricHob extends J_EAConversion implements Serializable {
 
-	private OL_EnergyCarriers energyCarrierProduced = OL_EnergyCarriers.HEAT;
-	private OL_EnergyCarriers energyCarrierConsumed = OL_EnergyCarriers.ELECTRICITY;
 	protected double outputTemperature_degC;
-	protected double capacityElectric_kW;
 
     /**
      * Default constructor
      */
-    public J_EAElectricHob(Agent ownerAgent, double capacityThermal_kW, double efficiency, double timestep_h, double outputTemperature_degC) {
+	// The efficiency is the amount of heat that is retained within the building
+    public J_EAElectricHob(Agent ownerAgent, double inputCapacity_kW, double efficiency, double timestep_h, double outputTemperature_degC) {
     	this.parentAgent= ownerAgent;
-	    //this.capacityHeat_kW = capacityThermal_kW;
+	    this.inputCapacity_kW = inputCapacity_kW;
 	    this.eta_r = efficiency;
-	    //this.capacityElectric_kW = capacityThermal_kW / eta_r;
+	    this.outputCapacity_kW = inputCapacity_kW * efficiency;
 	    this.timestep_h = timestep_h;
 	    this.outputTemperature_degC = outputTemperature_degC;
+		this.energyCarrierProduced = OL_EnergyCarriers.HEAT;
+		this.energyCarrierConsumed = OL_EnergyCarriers.ELECTRICITY;
 	    this.energyAssetType = OL_EnergyAssetType.ELECTRIC_HOB;
 	    this.activeProductionEnergyCarriers.add(this.energyCarrierProduced);		
 		this.activeConsumptionEnergyCarriers.add(this.energyCarrierConsumed);
 		registerEnergyAsset();
     }
 
-    @Override 
+    @Override
     public void operate( double ratioOfCapacity ) {
-    	//traceln("I convert now! GasBurner @ " + (ratioOfCapacity * 100) + " %");
-    	double heatProduction_kW = capacityElectric_kW * ratioOfCapacity * eta_r;
-		double electricityConsumption_kW = capacityElectric_kW * ratioOfCapacity;
+    	double heatProduction_kW = this.inputCapacity_kW * ratioOfCapacity * eta_r;
+		double electricityConsumption_kW = this.inputCapacity_kW * ratioOfCapacity;
 		this.energyUse_kW = (electricityConsumption_kW - heatProduction_kW);
 		this.energyUsed_kWh += timestep_h * (electricityConsumption_kW - heatProduction_kW); // This represents losses!
-		//double[] arr = {this.electricityProduction_kW, this.methaneProduction_kW, this.hydrogenProduction_kW, this.heatProduction_kW, this.electricityConsumption_kW, this.methaneConsumption_kW, this.hydrogenConsumption_kW, this.heatConsumption_kW };
-    	//return arr;
 		this.heatProduced_kWh += heatProduction_kW * timestep_h;
-
 		flowsMap.put(OL_EnergyCarriers.ELECTRICITY, electricityConsumption_kW);		
 		flowsMap.put(OL_EnergyCarriers.HEAT, -heatProduction_kW);		
-		
-		//return new Pair(this.flowsMap, this.energyUse_kW);
-
     }
     
 	@Override
@@ -47,8 +40,7 @@ public class J_EAElectricHob extends J_EAConversion implements Serializable {
 		return
 			"AssetType = " + energyAssetType + 
 			" parentAgent = " + parentAgent +", Energy consumed = " + this.energyUsed_kWh +
-			" capacityElectric_kW = " + this.capacityElectric_kW +" "+
-			//"capacityHeat_kW = " + this.capacityHeat_kW +" "+
+			" capacityElectric_kW = " + this.inputCapacity_kW +" "+
 			"eta_r = " + this.eta_r+" " +
 			"outputTemperature_degC = " + this.outputTemperature_degC + " "+
 			"energyUsed_kWh (losses) = " + this.energyUsed_kWh + " "+


### PR DESCRIPTION
- Cooking datasets for Summer/Winter Week and Year for EnergyModel, GC and EnergyCoop
- CookingTracker update to store/restore state
- Cooking tracker store/restore now called on rapidrun
- ElectricHOB fix for input/output capacity

Should be merged at the same time as interface-loader (https://github.com/Zenmo/zero_Interface-Loader/pull/40) & resultsUI (https://github.com/Zenmo/zero_results_UI/pull/26).