### PR TITLE
Primary Production of Heatpumps

### DIFF
--- a/_alp/Agents/EnergyCoop/Code/Functions.java
+++ b/_alp/Agents/EnergyCoop/Code/Functions.java
@@ -1522,6 +1522,7 @@ if(energyModel.b_isDaytime) {
 	v_rapidRunData.acc_daytimeElectricityConsumption_kW.addStep(fm_currentConsumptionFlows_kW.get(OL_EnergyCarriers.ELECTRICITY) );	
 	v_rapidRunData.acc_daytimeEnergyProduction_kW.addStep(v_currentPrimaryEnergyProduction_kW);
 	v_rapidRunData.acc_daytimeFinalEnergyConsumption_kW.addStep(v_currentFinalEnergyConsumption_kW);	
+	v_rapidRunData.acc_daytimePrimaryEnergyProductionHeatpumps_kW.addStep(v_currentPrimaryEnergyProductionHeatpumps_kW);	
 }
 
 // Weekend totals. Use overal-totals minus weekend totals to get weekday totals.
@@ -1536,6 +1537,7 @@ if (!energyModel.b_isWeekday) { //
 	v_rapidRunData.acc_weekendElectricityConsumption_kW.addStep(fm_currentConsumptionFlows_kW.get(OL_EnergyCarriers.ELECTRICITY) );
 	v_rapidRunData.acc_weekendEnergyProduction_kW.addStep(v_currentPrimaryEnergyProduction_kW);
 	v_rapidRunData.acc_weekendFinalEnergyConsumption_kW.addStep(v_currentFinalEnergyConsumption_kW);
+	v_rapidRunData.acc_weekendPrimaryEnergyProductionHeatpumps_kW.addStep(v_currentPrimaryEnergyProductionHeatpumps_kW);	
 }
 
 //========== SUMMER WEEK ==========//

--- a/_alp/Agents/EnergyDataViewer/Code/Functions.java
+++ b/_alp/Agents/EnergyDataViewer/Code/Functions.java
@@ -161,6 +161,8 @@ v_summerWeekElectricityConsumed_MWh = data.getRapidRunData().getSummerWeekElectr
 v_summerWeekElectricityProduced_MWh = data.getRapidRunData().getSummerWeekElectricityProduced_MWh();
 v_summerWeekElectricitySelfConsumed_MWh = data.getRapidRunData().getSummerWeekElectricitySelfConsumed_MWh();
 
+v_summerWeekPrimaryEnergyProductionHeatpumps_MWh = data.getRapidRunData().getSummerWeekPrimaryEnergyProductionHeatpumps_MWh();
+
 v_winterWeekEnergyImport_MWh = data.getRapidRunData().getWinterWeekEnergyImport_MWh();
 v_winterWeekEnergyExport_MWh = data.getRapidRunData().getWinterWeekEnergyExport_MWh();
 
@@ -171,6 +173,8 @@ v_winterWeekEnergySelfConsumed_MWh = data.getRapidRunData().getWinterWeekEnergyS
 v_winterWeekElectricityConsumed_MWh = data.getRapidRunData().getWinterWeekElectricityConsumed_MWh();
 v_winterWeekElectricityProduced_MWh = data.getRapidRunData().getWinterWeekElectricityProduced_MWh();
 v_winterWeekElectricitySelfConsumed_MWh = data.getRapidRunData().getWinterWeekElectricitySelfConsumed_MWh();
+
+v_winterWeekPrimaryEnergyProductionHeatpumps_MWh = data.getRapidRunData().getWinterWeekPrimaryEnergyProductionHeatpumps_MWh();
 
 //========== DAY/NIGHT ==========//
 fm_daytimeImports_MWh.clear();
@@ -198,6 +202,8 @@ v_daytimeElectricityConsumed_MWh = data.getRapidRunData().getDaytimeElectricityC
 v_daytimeElectricityProduced_MWh = data.getRapidRunData().getDaytimeElectricityProduced_MWh();
 v_daytimeElectricitySelfConsumed_MWh = data.getRapidRunData().getDaytimeElectricitySelfConsumed_MWh();
 
+v_daytimePrimaryEnergyProductionHeatpumps_MWh = data.getRapidRunData().getDaytimePrimaryEnergyProductionHeatpumps_MWh();
+
 v_nighttimeEnergyImport_MWh = data.getRapidRunData().getNighttimeEnergyImport_MWh();
 v_nighttimeEnergyExport_MWh = data.getRapidRunData().getNighttimeEnergyExport_MWh();
 
@@ -209,6 +215,7 @@ v_nighttimeElectricityConsumed_MWh = data.getRapidRunData().getNighttimeElectric
 v_nighttimeElectricityProduced_MWh = data.getRapidRunData().getNighttimeElectricityProduced_MWh();
 v_nighttimeElectricitySelfConsumed_MWh = data.getRapidRunData().getNighttimeElectricitySelfConsumed_MWh();
 
+v_nighttimePrimaryEnergyProductionHeatpumps_MWh = data.getRapidRunData().getNighttimePrimaryEnergyProductionHeatpumps_MWh();
 
 //========== WEEK/WEEKEND ==========//
 fm_weekdayImports_MWh.clear();
@@ -236,6 +243,8 @@ v_weekdayElectricityConsumed_MWh = data.getRapidRunData().getWeekdayElectricityC
 v_weekdayElectricityProduced_MWh = data.getRapidRunData().getWeekdayElectricityProduced_MWh();
 v_weekdayElectricitySelfConsumed_MWh = data.getRapidRunData().getWeekdayElectricitySelfConsumed_MWh();
 
+v_weekdayPrimaryEnergyProductionHeatpumps_MWh = data.getRapidRunData().getWeekdayPrimaryEnergyProductionHeatpumps_MWh();
+
 v_weekendEnergyImport_MWh = data.getRapidRunData().getWeekendEnergyImport_MWh();
 v_weekendEnergyExport_MWh = data.getRapidRunData().getWeekendEnergyExport_MWh();
 
@@ -246,6 +255,8 @@ v_weekendEnergySelfConsumed_MWh = data.getRapidRunData().getWeekendEnergySelfCon
 v_weekendElectricityConsumed_MWh = data.getRapidRunData().getWeekendElectricityConsumed_MWh();
 v_weekendElectricityProduced_MWh = data.getRapidRunData().getWeekendElectricityProduced_MWh();
 v_weekendElectricitySelfConsumed_MWh = data.getRapidRunData().getWeekendElectricitySelfConsumed_MWh();
+
+v_weekendPrimaryEnergyProductionHeatpumps_MWh = data.getRapidRunData().getWeekendPrimaryEnergyProductionHeatpumps_MWh();
 
 /*ALCODEEND*/}
 

--- a/_alp/Agents/EnergyDataViewer/Code/Functions.xml
+++ b/_alp/Agents/EnergyDataViewer/Code/Functions.xml
@@ -41,7 +41,7 @@
 		<X>1226</X>
 		<Y>-250</Y>
 		<Label>
-			<X>10</X>
+			<X>9</X>
 			<Y>0</Y>
 		</Label>
 		<PublicFlag>false</PublicFlag>

--- a/_alp/Agents/EnergyDataViewer/Levels/Level.level.xml
+++ b/_alp/Agents/EnergyDataViewer/Levels/Level.level.xml
@@ -181,7 +181,7 @@
 		<Id>1741792546461</Id>
 		<Name><![CDATA[txt_SummerWinterWeekTotals]]></Name>
 		<X>616</X>
-		<Y>640</Y>
+		<Y>620</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>

--- a/_alp/Agents/EnergyDataViewer/Variables.xml
+++ b/_alp/Agents/EnergyDataViewer/Variables.xml
@@ -329,7 +329,7 @@
 		<Id>1741792546581</Id>
 		<Name><![CDATA[v_summerWeekEnergySelfConsumed_MWh]]></Name>
 		<X>686</X>
-		<Y>900</Y>
+		<Y>880</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -348,7 +348,7 @@
 		<Id>1741792546583</Id>
 		<Name><![CDATA[v_summerWeekEnergyImport_MWh]]></Name>
 		<X>686</X>
-		<Y>720</Y>
+		<Y>700</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -367,7 +367,7 @@
 		<Id>1741792546585</Id>
 		<Name><![CDATA[v_summerWeekEnergyExport_MWh]]></Name>
 		<X>686</X>
-		<Y>740</Y>
+		<Y>720</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -386,7 +386,7 @@
 		<Id>1741792546587</Id>
 		<Name><![CDATA[v_summerWeekElectricitySelfConsumed_MWh]]></Name>
 		<X>686</X>
-		<Y>820</Y>
+		<Y>800</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1593,7 +1593,7 @@
 		<Id>1741792546743</Id>
 		<Name><![CDATA[fm_summerWeekImports_MWh]]></Name>
 		<X>686</X>
-		<Y>680</Y>
+		<Y>660</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1615,7 +1615,7 @@
 		<Id>1741792546745</Id>
 		<Name><![CDATA[fm_summerWeekExports_MWh]]></Name>
 		<X>686</X>
-		<Y>700</Y>
+		<Y>680</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1700,7 +1700,7 @@
 		<Id>1741792546753</Id>
 		<Name><![CDATA[v_summerWeekEnergyConsumed_MWh]]></Name>
 		<X>686</X>
-		<Y>880</Y>
+		<Y>860</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1719,7 +1719,7 @@
 		<Id>1741792546755</Id>
 		<Name><![CDATA[v_summerWeekEnergyProduced_MWh]]></Name>
 		<X>686</X>
-		<Y>860</Y>
+		<Y>840</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1738,7 +1738,7 @@
 		<Id>1741792546757</Id>
 		<Name><![CDATA[v_summerWeekElectricityConsumed_MWh]]></Name>
 		<X>686</X>
-		<Y>800</Y>
+		<Y>780</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1757,7 +1757,7 @@
 		<Id>1741792546759</Id>
 		<Name><![CDATA[v_summerWeekElectricityProduced_MWh]]></Name>
 		<X>686</X>
-		<Y>780</Y>
+		<Y>760</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2323,7 +2323,7 @@
 		<Id>1741792546817</Id>
 		<Name><![CDATA[v_weekendEnergyImport_MWh]]></Name>
 		<X>686</X>
-		<Y>2360</Y>
+		<Y>2390</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2342,7 +2342,7 @@
 		<Id>1741792546819</Id>
 		<Name><![CDATA[v_weekendEnergyExport_MWh]]></Name>
 		<X>686</X>
-		<Y>2380</Y>
+		<Y>2410</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2361,7 +2361,7 @@
 		<Id>1741792546821</Id>
 		<Name><![CDATA[v_weekendEnergyConsumed_MWh]]></Name>
 		<X>686</X>
-		<Y>2255</Y>
+		<Y>2285</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2380,7 +2380,7 @@
 		<Id>1741792546823</Id>
 		<Name><![CDATA[v_weekendEnergyProduced_MWh]]></Name>
 		<X>686</X>
-		<Y>2235</Y>
+		<Y>2265</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2399,7 +2399,7 @@
 		<Id>1741792546825</Id>
 		<Name><![CDATA[v_weekendEnergySelfConsumed_MWh]]></Name>
 		<X>686</X>
-		<Y>2275</Y>
+		<Y>2305</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2462,7 +2462,7 @@
 		<Id>1741792546831</Id>
 		<Name><![CDATA[v_weekendElectricityConsumed_MWh]]></Name>
 		<X>686</X>
-		<Y>2175</Y>
+		<Y>2205</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2572,7 +2572,7 @@
 		<Id>1741792546841</Id>
 		<Name><![CDATA[v_weekendElectricityProduced_MWh]]></Name>
 		<X>686</X>
-		<Y>2155</Y>
+		<Y>2185</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2594,7 +2594,7 @@
 		<Id>1741792546843</Id>
 		<Name><![CDATA[v_weekendElectricitySelfConsumed_MWh]]></Name>
 		<X>686</X>
-		<Y>2195</Y>
+		<Y>2225</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2704,7 +2704,7 @@
 		<Id>1741792546853</Id>
 		<Name><![CDATA[fm_weekendImports_MWh]]></Name>
 		<X>686</X>
-		<Y>2320</Y>
+		<Y>2350</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2726,7 +2726,7 @@
 		<Id>1741792546855</Id>
 		<Name><![CDATA[fm_weekendExports_MWh]]></Name>
 		<X>686</X>
-		<Y>2340</Y>
+		<Y>2370</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -3796,6 +3796,120 @@
 		<Name><![CDATA[v_gridCapacityDelivery_kW_rapidRun]]></Name>
 		<X>1215</X>
 		<Y>455</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Properties SaveInSnapshot="true"
+              Constant="false"
+              AccessType="public"
+              StaticVariable="false">
+			<Type><![CDATA[double]]></Type>
+		</Properties>
+	</Variable>
+	<Variable Class="PlainVariable">
+		<Id>1743067237799</Id>
+		<Name><![CDATA[v_summerWeekPrimaryEnergyProductionHeatpumps_MWh]]></Name>
+		<X>685</X>
+		<Y>910</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Properties SaveInSnapshot="true"
+              Constant="false"
+              AccessType="public"
+              StaticVariable="false">
+			<Type><![CDATA[double]]></Type>
+		</Properties>
+	</Variable>
+	<Variable Class="PlainVariable">
+		<Id>1743067333060</Id>
+		<Name><![CDATA[v_winterWeekPrimaryEnergyProductionHeatpumps_MWh]]></Name>
+		<X>685</X>
+		<Y>1195</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Properties SaveInSnapshot="true"
+              Constant="false"
+              AccessType="public"
+              StaticVariable="false">
+			<Type><![CDATA[double]]></Type>
+		</Properties>
+	</Variable>
+	<Variable Class="PlainVariable">
+		<Id>1743067347245</Id>
+		<Name><![CDATA[v_daytimePrimaryEnergyProductionHeatpumps_MWh]]></Name>
+		<X>685</X>
+		<Y>1515</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Properties SaveInSnapshot="true"
+              Constant="false"
+              AccessType="public"
+              StaticVariable="false">
+			<Type><![CDATA[double]]></Type>
+		</Properties>
+	</Variable>
+	<Variable Class="PlainVariable">
+		<Id>1743067361421</Id>
+		<Name><![CDATA[v_nighttimePrimaryEnergyProductionHeatpumps_MWh]]></Name>
+		<X>686</X>
+		<Y>1805</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Properties SaveInSnapshot="true"
+              Constant="false"
+              AccessType="public"
+              StaticVariable="false">
+			<Type><![CDATA[double]]></Type>
+		</Properties>
+	</Variable>
+	<Variable Class="PlainVariable">
+		<Id>1743067393031</Id>
+		<Name><![CDATA[v_weekdayPrimaryEnergyProductionHeatpumps_MWh]]></Name>
+		<X>686</X>
+		<Y>2148</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Properties SaveInSnapshot="true"
+              Constant="false"
+              AccessType="public"
+              StaticVariable="false">
+			<Type><![CDATA[double]]></Type>
+		</Properties>
+	</Variable>
+	<Variable Class="PlainVariable">
+		<Id>1743067406399</Id>
+		<Name><![CDATA[v_weekendPrimaryEnergyProductionHeatpumps_MWh]]></Name>
+		<X>686</X>
+		<Y>2442</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>

--- a/_alp/Agents/EnergyModel/Code/Functions.java
+++ b/_alp/Agents/EnergyModel/Code/Functions.java
@@ -1899,6 +1899,8 @@ if(b_isDaytime) {
 	v_rapidRunData.acc_daytimeElectricityConsumption_kW.addStep(fm_currentConsumptionFlows_kW.get(OL_EnergyCarriers.ELECTRICITY) );	
 	v_rapidRunData.acc_daytimeEnergyProduction_kW.addStep(v_currentPrimaryEnergyProduction_kW);
 	v_rapidRunData.acc_daytimeFinalEnergyConsumption_kW.addStep(v_currentFinalEnergyConsumption_kW);	
+	v_rapidRunData.acc_daytimePrimaryEnergyProductionHeatpumps_kW.addStep(v_currentPrimaryEnergyProductionHeatpumps_kW);	
+
 }
 
 // Weekend totals. Use overal-totals minus weekend totals to get weekday totals.
@@ -1913,7 +1915,8 @@ if (!b_isWeekday) { //
 	v_rapidRunData.acc_weekendElectricityConsumption_kW.addStep(fm_currentConsumptionFlows_kW.get(OL_EnergyCarriers.ELECTRICITY) );
 	v_rapidRunData.acc_weekendEnergyProduction_kW.addStep(v_currentPrimaryEnergyProduction_kW);
 	v_rapidRunData.acc_weekendFinalEnergyConsumption_kW.addStep(v_currentFinalEnergyConsumption_kW);
-	
+	v_rapidRunData.acc_weekendPrimaryEnergyProductionHeatpumps_kW.addStep(v_currentPrimaryEnergyProductionHeatpumps_kW);	
+
 }
 
 

--- a/_alp/Agents/GridConnection/Code/Functions.java
+++ b/_alp/Agents/GridConnection/Code/Functions.java
@@ -2242,6 +2242,7 @@ if(energyModel.b_isDaytime) {
 	v_rapidRunData.acc_daytimeElectricityConsumption_kW.addStep(fm_currentConsumptionFlows_kW.get(OL_EnergyCarriers.ELECTRICITY) );	
 	v_rapidRunData.acc_daytimeEnergyProduction_kW.addStep(v_currentPrimaryEnergyProduction_kW);
 	v_rapidRunData.acc_daytimeFinalEnergyConsumption_kW.addStep(v_currentFinalEnergyConsumption_kW);	
+	v_rapidRunData.acc_daytimePrimaryEnergyProductionHeatpumps_kW.addStep(v_currentPrimaryEnergyProductionHeatpumps_kW);	
 }
 
 // Weekend totals. Use overal-totals minus weekend totals to get weekday totals.
@@ -2256,8 +2257,8 @@ if (!energyModel.b_isWeekday) { //
 	v_rapidRunData.acc_weekendElectricityConsumption_kW.addStep(fm_currentConsumptionFlows_kW.get(OL_EnergyCarriers.ELECTRICITY) );
 	v_rapidRunData.acc_weekendEnergyProduction_kW.addStep(v_currentPrimaryEnergyProduction_kW);
 	v_rapidRunData.acc_weekendFinalEnergyConsumption_kW.addStep(v_currentFinalEnergyConsumption_kW);
+	v_rapidRunData.acc_weekendPrimaryEnergyProductionHeatpumps_kW.addStep(v_currentPrimaryEnergyProductionHeatpumps_kW);	
 }
-
 
 // Further Subdivision of asset types within energy carriers
 v_fixedConsumptionElectric_kW = 0;

--- a/_alp/Classes/Class.J_AccumulatorMap.java
+++ b/_alp/Classes/Class.J_AccumulatorMap.java
@@ -57,6 +57,10 @@ public class J_AccumulatorMap implements Serializable {
 		return totalIntegral_kWh;
 	}
 	
+	public double totalIntegral_MWh() {
+		return this.totalIntegral_kWh() / 1000;
+	}
+	
 	public double totalIntegralPos_kWh() {
 		double totalIntegralPos_kWh = 0.0;
 		for (var EC : energyCarrierList) {
@@ -65,12 +69,20 @@ public class J_AccumulatorMap implements Serializable {
 		return totalIntegralPos_kWh;
 	}
 	
+	public double totalIntegralPos_MWh() {
+		return this.totalIntegralPos_kWh() / 1000;
+	}
+	
 	public double totalIntegralNeg_kWh() {
 		double totalIntegralNeg_kWh = 0.0;
 		for (var EC : energyCarrierList) {
 			totalIntegralNeg_kWh += accumulatorArray[EC.ordinal()].getIntegralNeg_kWh();
 		}
 		return totalIntegralNeg_kWh;
+	}
+	
+	public double totalIntegralNeg_MWh() {
+		return this.totalIntegralNeg_kWh() / 1000;
 	}
 	
 	public void clear() {

--- a/_alp/Classes/Class.J_RapidRunData.java
+++ b/_alp/Classes/Class.J_RapidRunData.java
@@ -625,7 +625,7 @@ public class J_RapidRunData {
         return this.am_winterWeekBalanceAccumulators_kW.totalIntegralPos_MWh();
     }
     public double getWinterWeekEnergyExport_MWh() {
-        return -this.am_winterWeekBalanceAccumulators_kW.totalIntegralPos_MWh();
+        return -this.am_winterWeekBalanceAccumulators_kW.totalIntegralNeg_MWh();
     }    
     public double getWinterWeekExport_MWh( OL_EnergyCarriers EC ) {
     	if (!this.activeEnergyCarriers.contains(EC)) {

--- a/_alp/Classes/Class.J_RapidRunData.java
+++ b/_alp/Classes/Class.J_RapidRunData.java
@@ -107,6 +107,8 @@ public class J_RapidRunData {
     public ZeroAccumulator acc_daytimeElectricityConsumption_kW;
     public ZeroAccumulator acc_daytimeElectricityProduction_kW;
     
+    public ZeroAccumulator acc_daytimePrimaryEnergyProductionHeatpumps_kW;
+    
     //Weekend/day
     public J_AccumulatorMap am_weekendExports_kW = new J_AccumulatorMap();
     public J_AccumulatorMap am_weekendImports_kW = new J_AccumulatorMap();
@@ -116,6 +118,7 @@ public class J_RapidRunData {
     public ZeroAccumulator acc_weekendFinalEnergyConsumption_kW;
     public ZeroAccumulator acc_weekendEnergyProduction_kW;
 
+    public ZeroAccumulator acc_weekendPrimaryEnergyProductionHeatpumps_kW;
 
     
     /**
@@ -230,6 +233,8 @@ public class J_RapidRunData {
 	    acc_daytimeElectricityProduction_kW = new ZeroAccumulator(false, timeStep_h, 0.5 * (simDuration_h));
 	    acc_daytimeElectricityConsumption_kW = new ZeroAccumulator(false, timeStep_h, 0.5 * (simDuration_h));
 	
+	    acc_daytimePrimaryEnergyProductionHeatpumps_kW = new ZeroAccumulator(false, timeStep_h, 0.5 * (simDuration_h));
+	    		
 	    //========== WEEKEND ACCUMULATORS ==========//
 	    am_weekendImports_kW.createEmptyAccumulators( v_activeEnergyCarriers, false, timeStep_h, 2 / 7  * (simDuration_h) + 48);
 	    am_weekendExports_kW.createEmptyAccumulators( v_activeEnergyCarriers, false, timeStep_h, 2 / 7 * (simDuration_h) + 48);
@@ -239,7 +244,9 @@ public class J_RapidRunData {
 	    //acc_weekendEnergyCurtailed_kW = new ZeroAccumulator(false, timeStep_h, simDuration_h);
 	    acc_weekendElectricityProduction_kW = new ZeroAccumulator(false, timeStep_h, 2 / 7  * (simDuration_h) + 48);
 	    acc_weekendElectricityConsumption_kW = new ZeroAccumulator(false, timeStep_h, 2 / 7  * (simDuration_h) + 48);
-	}
+	
+	    acc_weekendPrimaryEnergyProductionHeatpumps_kW = new ZeroAccumulator(false, timeStep_h,  2 / 7 * (simDuration_h) + 48);
+    }
 
     public void resetAccumulators(double simDuration_h, double timeStep_h, EnumSet<OL_EnergyCarriers> v_activeEnergyCarriers, EnumSet<OL_EnergyCarriers> v_activeConsumptionEnergyCarriers, EnumSet<OL_EnergyCarriers> v_activeProductionEnergyCarriers) {
     	this.activeEnergyCarriers = v_activeEnergyCarriers;
@@ -345,15 +352,18 @@ public class J_RapidRunData {
     	acc_daytimeEnergyProduction_kW.reset();
     	acc_daytimeFinalEnergyConsumption_kW.reset();
 
+    	acc_daytimePrimaryEnergyProductionHeatpumps_kW.reset();
+    	
     	// Weekend
     	am_weekendImports_kW.createEmptyAccumulators( v_activeEnergyCarriers, false, timeStep_h, 2 / 7  * (simDuration_h) + 48);
     	am_weekendExports_kW.createEmptyAccumulators( v_activeEnergyCarriers, false, timeStep_h, 2 / 7 * (simDuration_h) + 48);
 
-    	// Energy / Electricity
     	acc_weekendElectricityProduction_kW.reset();
     	acc_weekendElectricityConsumption_kW.reset();
     	acc_weekendEnergyProduction_kW.reset();
     	acc_weekendFinalEnergyConsumption_kW.reset();
+    	
+    	acc_weekendPrimaryEnergyProductionHeatpumps_kW.reset();
     }
     
     public J_RapidRunData getClone() {
@@ -439,6 +449,7 @@ public class J_RapidRunData {
         clone.acc_daytimeEnergyProduction_kW = acc_daytimeEnergyProduction_kW.getClone();
         clone.acc_daytimeElectricityConsumption_kW = acc_daytimeElectricityConsumption_kW.getClone();
         clone.acc_daytimeElectricityProduction_kW = acc_daytimeElectricityProduction_kW.getClone();
+        clone.acc_daytimePrimaryEnergyProductionHeatpumps_kW = acc_daytimePrimaryEnergyProductionHeatpumps_kW.getClone();
         //Weekend/day
         clone.acc_weekendElectricityConsumption_kW = this.acc_weekendElectricityConsumption_kW.getClone();
         clone.acc_weekendElectricityProduction_kW = this.acc_weekendElectricityProduction_kW.getClone();
@@ -446,6 +457,7 @@ public class J_RapidRunData {
         clone.acc_weekendEnergyProduction_kW = this.acc_weekendEnergyProduction_kW.getClone();
         clone.am_weekendExports_kW = this.am_weekendExports_kW.getClone();
         clone.am_weekendImports_kW = this.am_weekendImports_kW.getClone();
+        clone.acc_weekendPrimaryEnergyProductionHeatpumps_kW = acc_weekendPrimaryEnergyProductionHeatpumps_kW.getClone();
         
         clone.assetsMetaData = this.assetsMetaData.getClone();
         clone.connectionMetaData = this.connectionMetaData.getClone();
@@ -496,36 +508,28 @@ public class J_RapidRunData {
     }
     
     public double getTotalElectricityConsumed_MWh() { 
-        return am_dailyAverageConsumptionAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_kWh() / 1000; 
+        return am_dailyAverageConsumptionAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh(); 
     }
     public double getTotalElectricityProduced_MWh() { 
-        return am_dailyAverageProductionAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_kWh() / 1000; 
+        return am_dailyAverageProductionAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh(); 
     }
     public double getTotalElectricitySelfConsumed_MWh() { 
-        return max(0, getTotalElectricityConsumed_MWh() - am_totalBalanceAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegralPos_kWh() / 1000); 
+        return max(0, getTotalElectricityConsumed_MWh() - am_totalBalanceAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegralPos_MWh()); 
     }
     public double getTotalEnergyConsumed_MWh() { 
-        return acc_dailyAverageFinalEnergyConsumption_kW.getIntegral_kWh() / 1000; 
+        return acc_dailyAverageFinalEnergyConsumption_kW.getIntegral_MWh(); 
     }
     public double getTotalEnergyProduced_MWh() { 
-        return acc_dailyAverageEnergyProduction_kW.getIntegral_kWh() / 1000; 
+        return acc_dailyAverageEnergyProduction_kW.getIntegral_MWh(); 
     }
     public double getTotalEnergyCurtailed_MWh() { 
-        return acc_totalEnergyCurtailed_kW.getIntegral_kWh() / 1000; 
+        return acc_totalEnergyCurtailed_kW.getIntegral_MWh(); 
     }
     public double getTotalEnergyImport_MWh() { 
-    	double totalEnergyImport_kWh = 0.0;
-    	for (OL_EnergyCarriers EC : activeEnergyCarriers) {
-    		totalEnergyImport_kWh+=am_totalBalanceAccumulators_kW.get(EC).getIntegralPos_kWh();
-    	}
-        return totalEnergyImport_kWh/1000; 
-    }   
+        return this.am_totalBalanceAccumulators_kW.totalIntegralPos_MWh();
+    }
     public double getTotalEnergyExport_MWh() { 
-    	double totalEnergyExport_kWh = 0.0;
-    	for (OL_EnergyCarriers EC : activeEnergyCarriers) {
-    		totalEnergyExport_kWh+= - am_totalBalanceAccumulators_kW.get(EC).getIntegralNeg_kWh();
-    	}
-        return totalEnergyExport_kWh/1000; 
+        return -this.am_totalBalanceAccumulators_kW.totalIntegralNeg_MWh();
     }
     
     public double getTotalExport_MWh( OL_EnergyCarriers EC ) {
@@ -545,45 +549,37 @@ public class J_RapidRunData {
         return max(0, getTotalEnergyConsumed_MWh() - getTotalEnergyImport_MWh()); 
     }
     public double getTotalPrimaryEnergyProductionHeatpumps_MWh() { 
-        return acc_totalPrimaryEnergyProductionHeatpumps_kW.getIntegral_kWh() / 1000; 
+        return acc_totalPrimaryEnergyProductionHeatpumps_kW.getIntegral_MWh(); 
     }
     public double getTotalDistrictHeatingConsumption_MWh() {
-    	return acc_dailyAverageDistrictHeatingConsumption_kW.getIntegral_kWh() / 1000;
+    	return acc_dailyAverageDistrictHeatingConsumption_kW.getIntegral_MWh();
     }
     
 
 // Summerweek Getters
     public double getSummerWeekElectricityConsumed_MWh() {
-        return am_summerWeekConsumptionAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_kWh() / 1000;
+        return am_summerWeekConsumptionAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh();
     }
     public double getSummerWeekElectricityProduced_MWh() {
-        return am_summerWeekProductionAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_kWh() / 1000;
+        return am_summerWeekProductionAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh();
     }
     public double getSummerWeekElectricitySelfConsumed_MWh() {
-        return max(0, getSummerWeekElectricityConsumed_MWh() - am_summerWeekBalanceAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegralPos_kWh() / 1000);
+        return max(0, getSummerWeekElectricityConsumed_MWh() - am_summerWeekBalanceAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegralPos_MWh());
     }
     public double getSummerWeekEnergyConsumed_MWh() {
-        return acc_summerWeekFinalEnergyConsumption_kW.getIntegral_kWh() / 1000;
+        return acc_summerWeekFinalEnergyConsumption_kW.getIntegral_MWh();
     }
     public double getSummerWeekEnergyProduced_MWh() {
-        return acc_summerWeekEnergyProduction_kW.getIntegral_kWh() / 1000;
+        return acc_summerWeekEnergyProduction_kW.getIntegral_MWh();
     }
     public double getSummerWeekEnergyCurtailed_MWh() {
-        return acc_summerWeekEnergyCurtailed_kW.getIntegral_kWh() / 1000;
+        return acc_summerWeekEnergyCurtailed_kW.getIntegral_MWh();
     }
     public double getSummerWeekEnergyImport_MWh() {
-        double summerWeekEnergyImport_kWh = 0.0;
-    	for (OL_EnergyCarriers EC : activeEnergyCarriers) {
-    		summerWeekEnergyImport_kWh+=am_summerWeekBalanceAccumulators_kW.get(EC).getIntegralPos_kWh();
-    	}
-        return summerWeekEnergyImport_kWh/1000;
+        return this.am_summerWeekBalanceAccumulators_kW.totalIntegralPos_MWh();
     }
     public double getSummerWeekEnergyExport_MWh() {
-        double summerWeekEnergyExport_kWh = 0.0;
-    	for (OL_EnergyCarriers EC : activeEnergyCarriers) {
-    		summerWeekEnergyExport_kWh+= - am_summerWeekBalanceAccumulators_kW.get(EC).getIntegralNeg_kWh();
-    	}
-        return summerWeekEnergyExport_kWh/1000;
+        return -this.am_summerWeekBalanceAccumulators_kW.totalIntegralNeg_MWh();
     }    
     
     public double getSummerWeekExport_MWh( OL_EnergyCarriers EC ) {
@@ -603,41 +599,33 @@ public class J_RapidRunData {
         return max(0, getSummerWeekEnergyConsumed_MWh() - getSummerWeekEnergyImport_MWh());
     }
     public double getSummerWeekPrimaryEnergyProductionHeatpumps_MWh() {
-        return acc_summerWeekPrimaryEnergyProductionHeatpumps_kW.getIntegral_kWh() / 1000;
+        return acc_summerWeekPrimaryEnergyProductionHeatpumps_kW.getIntegral_MWh();
     }
     
 // Winterweek Getters
     public double getWinterWeekElectricityConsumed_MWh() {
-        return am_winterWeekConsumptionAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_kWh() / 1000;
+        return am_winterWeekConsumptionAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh();
     }
     public double getWinterWeekElectricityProduced_MWh() {
-        return am_winterWeekProductionAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_kWh() / 1000;
+        return am_winterWeekProductionAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh();
     }
     public double getWinterWeekElectricitySelfConsumed_MWh() {
-        return max(0, getWinterWeekElectricityConsumed_MWh() - am_winterWeekBalanceAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegralPos_kWh() / 1000);
+        return max(0, getWinterWeekElectricityConsumed_MWh() - am_winterWeekBalanceAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegralPos_MWh());
     }
     public double getWinterWeekEnergyConsumed_MWh() {
-        return acc_winterWeekFinalEnergyConsumption_kW.getIntegral_kWh() / 1000;
+        return acc_winterWeekFinalEnergyConsumption_kW.getIntegral_MWh();
     }
     public double getWinterWeekEnergyProduced_MWh() {
-        return acc_winterWeekEnergyProduction_kW.getIntegral_kWh() / 1000;
+        return acc_winterWeekEnergyProduction_kW.getIntegral_MWh();
     }
     public double getWinterWeekEnergyCurtailed_MWh() {
-        return acc_winterWeekEnergyCurtailed_kW.getIntegral_kWh() / 1000;
+        return acc_winterWeekEnergyCurtailed_kW.getIntegral_MWh();
     }
     public double getWinterWeekEnergyImport_MWh() {
-        double winterWeekEnergyImport_kWh = 0.0;
-    	for (OL_EnergyCarriers EC : activeEnergyCarriers) {
-    		winterWeekEnergyImport_kWh+=am_winterWeekBalanceAccumulators_kW.get(EC).getIntegralPos_kWh();
-    	}
-        return winterWeekEnergyImport_kWh/1000;
+        return this.am_winterWeekBalanceAccumulators_kW.totalIntegralPos_MWh();
     }
     public double getWinterWeekEnergyExport_MWh() {
-        double winterWeekEnergyExport_kWh = 0.0;
-    	for (OL_EnergyCarriers EC : activeEnergyCarriers) {
-    		winterWeekEnergyExport_kWh+= - am_winterWeekBalanceAccumulators_kW.get(EC).getIntegralNeg_kWh();
-    	}
-        return winterWeekEnergyExport_kWh/1000;
+        return -this.am_winterWeekBalanceAccumulators_kW.totalIntegralPos_MWh();
     }    
     public double getWinterWeekExport_MWh( OL_EnergyCarriers EC ) {
     	if (!this.activeEnergyCarriers.contains(EC)) {
@@ -656,30 +644,30 @@ public class J_RapidRunData {
         return max(0, getWinterWeekEnergyConsumed_MWh() - getWinterWeekEnergyImport_MWh());
     }
     public double getWinterWeekPrimaryEnergyProductionHeatpumps_MWh() {
-        return acc_winterWeekPrimaryEnergyProductionHeatpumps_kW.getIntegral_kWh() / 1000;
+        return acc_winterWeekPrimaryEnergyProductionHeatpumps_kW.getIntegral_MWh();
     }
     
 // Daytime getters    
     public double getDaytimeElectricityConsumed_MWh() { 
-        return acc_daytimeElectricityConsumption_kW.getIntegral_kWh() / 1000; 
+        return acc_daytimeElectricityConsumption_kW.getIntegral_MWh(); 
     }
     public double getDaytimeElectricityProduced_MWh() { 
-        return acc_daytimeElectricityProduction_kW.getIntegral_kWh() / 1000; 
+        return acc_daytimeElectricityProduction_kW.getIntegral_MWh(); 
     }
     public double getDaytimeElectricitySelfConsumed_MWh() { 
-        return max(0, getDaytimeElectricityConsumed_MWh() - am_daytimeImports_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_kWh()/1000); 
+        return max(0, getDaytimeElectricityConsumed_MWh() - am_daytimeImports_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh()); 
     }
     public double getDaytimeEnergyConsumed_MWh() { 
-        return acc_daytimeFinalEnergyConsumption_kW.getIntegral_kWh() / 1000; 
+        return acc_daytimeFinalEnergyConsumption_kW.getIntegral_MWh(); 
     }
     public double getDaytimeEnergyProduced_MWh() { 
-        return acc_daytimeEnergyProduction_kW.getIntegral_kWh() / 1000; 
+        return acc_daytimeEnergyProduction_kW.getIntegral_MWh(); 
     }
     public double getDaytimeEnergyExport_MWh() { 
-        return am_daytimeExports_kW.totalIntegral_kWh()/1000; 
+        return am_daytimeExports_kW.totalIntegral_MWh(); 
     }
     public double getDaytimeEnergyImport_MWh() { 
-        return am_daytimeImports_kW.totalIntegral_kWh()/1000; 
+        return am_daytimeImports_kW.totalIntegral_MWh(); 
     }
     public double getDaytimeEnergySelfConsumed_MWh() { 
         return max(0, getDaytimeEnergyProduced_MWh() - getDaytimeEnergyExport_MWh()); 
@@ -688,15 +676,17 @@ public class J_RapidRunData {
     	if (!this.activeEnergyCarriers.contains(EC)) {
     		throw new RuntimeException("RapidRunData class does not contain energycarrier: " + EC);
     	}
-    	return this.am_daytimeExports_kW.get(EC).getIntegral_kWh() / 1000;
+    	return this.am_daytimeExports_kW.get(EC).getIntegral_MWh();
     }
     public double getDaytimeImport_MWh( OL_EnergyCarriers EC ) {
     	if (!this.activeEnergyCarriers.contains(EC)) {
     		throw new RuntimeException("RapidRunData class does not contain energycarrier: " + EC);
     	}
-    	return this.am_daytimeImports_kW.get(EC).getIntegral_kWh() / 1000;
+    	return this.am_daytimeImports_kW.get(EC).getIntegral_MWh();
     }
-    
+    public double getDaytimePrimaryEnergyProductionHeatpumps_MWh() {
+    	return this.acc_daytimePrimaryEnergyProductionHeatpumps_kW.getIntegral_MWh();
+    }
 //Nighttime Getters
     public double getNighttimeElectricityConsumed_MWh() { 
         return getTotalElectricityConsumed_MWh() - getDaytimeElectricityConsumed_MWh(); 
@@ -705,7 +695,7 @@ public class J_RapidRunData {
         return getTotalElectricityProduced_MWh() - getDaytimeElectricityProduced_MWh(); 
     }
     public double getNighttimeElectricitySelfConsumed_MWh() { 
-        return max(0,getNighttimeElectricityConsumed_MWh() - (am_totalBalanceAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_kWh()/1000 - am_daytimeImports_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_kWh()/1000)); 
+        return max(0,getNighttimeElectricityConsumed_MWh() - (am_totalBalanceAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh() - am_daytimeImports_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh())); 
     }
     public double getNighttimeEnergyConsumed_MWh() { 
         return getTotalEnergyConsumed_MWh() - getDaytimeEnergyConsumed_MWh(); 
@@ -726,13 +716,16 @@ public class J_RapidRunData {
     	if (!this.activeEnergyCarriers.contains(EC)) {
     		throw new RuntimeException("RapidRunData class does not contain energycarrier: " + EC);
     	}
-    	return -this.am_totalBalanceAccumulators_kW.get(EC).getIntegralNeg_kWh() / 1000 - this.getDaytimeExport_MWh(EC);
+    	return -this.am_totalBalanceAccumulators_kW.get(EC).getIntegralNeg_MWh() - this.getDaytimeExport_MWh(EC);
     }
     public double getNighttimeImport_MWh( OL_EnergyCarriers EC ) {
     	if (!this.activeEnergyCarriers.contains(EC)) {
     		throw new RuntimeException("RapidRunData class does not contain energycarrier: " + EC);
     	}
-    	return this.am_totalBalanceAccumulators_kW.get(EC).getIntegralPos_kWh() / 1000 - this.getDaytimeImport_MWh(EC);
+    	return this.am_totalBalanceAccumulators_kW.get(EC).getIntegralPos_MWh() - this.getDaytimeImport_MWh(EC);
+    }
+    public double getNighttimePrimaryEnergyProductionHeatpumps_MWh() {
+    	return this.getTotalPrimaryEnergyProductionHeatpumps_MWh() - this.getDaytimePrimaryEnergyProductionHeatpumps_MWh();
     }
 // Weekday Getters
     public double getWeekdayElectricityConsumed_MWh() { 
@@ -742,7 +735,7 @@ public class J_RapidRunData {
         return getTotalElectricityProduced_MWh() - getWeekendElectricityProduced_MWh(); 
     }
     public double getWeekdayElectricitySelfConsumed_MWh() { 
-        return max(0,getWeekdayElectricityConsumed_MWh() - (am_totalBalanceAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_kWh()/1000 - am_weekendImports_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_kWh()/1000)); 
+        return max(0,getWeekdayElectricityConsumed_MWh() - (am_totalBalanceAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh() - am_weekendImports_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh())); 
     }
     public double getWeekdayEnergyConsumed_MWh() { 
         return getTotalEnergyConsumed_MWh() - getWeekendEnergyConsumed_MWh(); 
@@ -763,35 +756,38 @@ public class J_RapidRunData {
     	if (!this.activeEnergyCarriers.contains(EC)) {
     		throw new RuntimeException("RapidRunData class does not contain energycarrier: " + EC);
     	}
-    	return -this.am_totalBalanceAccumulators_kW.get(EC).getIntegralNeg_kWh() / 1000 - this.getWeekendExport_MWh(EC);
+    	return -this.am_totalBalanceAccumulators_kW.get(EC).getIntegralNeg_MWh() - this.getWeekendExport_MWh(EC);
     }
     public double getWeekdayImport_MWh( OL_EnergyCarriers EC ) {
     	if (!this.activeEnergyCarriers.contains(EC)) {
     		throw new RuntimeException("RapidRunData class does not contain energycarrier: " + EC);
     	}
-    	return this.am_totalBalanceAccumulators_kW.get(EC).getIntegralPos_kWh() / 1000 - this.getWeekendImport_MWh(EC);
+    	return this.am_totalBalanceAccumulators_kW.get(EC).getIntegralPos_MWh() - this.getWeekendImport_MWh(EC);
     }
+    public double getWeekdayPrimaryEnergyProductionHeatpumps_MWh() {
+    	return this.getTotalPrimaryEnergyProductionHeatpumps_MWh() - this.getWeekendPrimaryEnergyProductionHeatpumps_MWh();
+    }    
 //Weekend Getters
     public double getWeekendElectricityConsumed_MWh() { 
-        return acc_weekendElectricityConsumption_kW.getIntegral_kWh() / 1000; 
+        return acc_weekendElectricityConsumption_kW.getIntegral_MWh(); 
     }
     public double getWeekendElectricityProduced_MWh() { 
-        return acc_weekendElectricityProduction_kW.getIntegral_kWh() / 1000; 
+        return acc_weekendElectricityProduction_kW.getIntegral_MWh(); 
     }
     public double getWeekendElectricitySelfConsumed_MWh() { 
-        return max(0, getWeekendElectricityConsumed_MWh() - am_weekendImports_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_kWh()/1000); 
+        return max(0, getWeekendElectricityConsumed_MWh() - am_weekendImports_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh()); 
     }
     public double getWeekendEnergyConsumed_MWh() { 
-        return acc_weekendFinalEnergyConsumption_kW.getIntegral_kWh() / 1000; 
+        return acc_weekendFinalEnergyConsumption_kW.getIntegral_MWh(); 
     }
     public double getWeekendEnergyProduced_MWh() { 
-        return acc_weekendEnergyProduction_kW.getIntegral_kWh() / 1000; 
+        return acc_weekendEnergyProduction_kW.getIntegral_MWh(); 
     }
     public double getWeekendEnergyExport_MWh() { 
-        return am_weekendExports_kW.totalIntegral_kWh()/1000; 
+        return am_weekendExports_kW.totalIntegral_MWh(); 
     }
     public double getWeekendEnergyImport_MWh() { 
-        return am_weekendImports_kW.totalIntegral_kWh()/1000; 
+        return am_weekendImports_kW.totalIntegral_MWh(); 
     }
     public double getWeekendEnergySelfConsumed_MWh() { 
         return max(0, getWeekendEnergyProduced_MWh() - getWeekendEnergyExport_MWh()); 
@@ -800,16 +796,19 @@ public class J_RapidRunData {
     	if (!this.activeEnergyCarriers.contains(EC)) {
     		throw new RuntimeException("RapidRunData class does not contain energycarrier: " + EC);
     	}
-    	return this.am_weekendExports_kW.get(EC).getIntegral_kWh() / 1000;
+    	return this.am_weekendExports_kW.get(EC).getIntegral_MWh();
     }
     public double getWeekendImport_MWh( OL_EnergyCarriers EC ) {
     	if (!this.activeEnergyCarriers.contains(EC)) {
     		throw new RuntimeException("RapidRunData class does not contain energycarrier: " + EC);
     	}
-    	return this.am_weekendImports_kW.get(EC).getIntegral_kWh() / 1000;
+    	return this.am_weekendImports_kW.get(EC).getIntegral_MWh();
     }
-    
-    
+    public double getWeekendPrimaryEnergyProductionHeatpumps_MWh() {
+    	return this.acc_weekendPrimaryEnergyProductionHeatpumps_kW.getIntegral_MWh();
+    } 
+	
+
 //toString()
     public String toString() {
 		return super.toString();

--- a/_alp/Classes/Class.J_RapidRunData.java
+++ b/_alp/Classes/Class.J_RapidRunData.java
@@ -514,7 +514,7 @@ public class J_RapidRunData {
         return am_dailyAverageProductionAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh(); 
     }
     public double getTotalElectricitySelfConsumed_MWh() { 
-        return max(0, getTotalElectricityConsumed_MWh() - am_totalBalanceAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegralPos_MWh()); 
+        return max(0, getTotalElectricityConsumed_MWh() - getTotalImport_MWh(OL_EnergyCarriers.ELECTRICITY));
     }
     public double getTotalEnergyConsumed_MWh() { 
         return acc_dailyAverageFinalEnergyConsumption_kW.getIntegral_MWh(); 
@@ -564,7 +564,7 @@ public class J_RapidRunData {
         return am_summerWeekProductionAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh();
     }
     public double getSummerWeekElectricitySelfConsumed_MWh() {
-        return max(0, getSummerWeekElectricityConsumed_MWh() - am_summerWeekBalanceAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegralPos_MWh());
+        return max(0, getSummerWeekElectricityConsumed_MWh() - getSummerWeekImport_MWh(OL_EnergyCarriers.ELECTRICITY));
     }
     public double getSummerWeekEnergyConsumed_MWh() {
         return acc_summerWeekFinalEnergyConsumption_kW.getIntegral_MWh();
@@ -610,7 +610,7 @@ public class J_RapidRunData {
         return am_winterWeekProductionAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh();
     }
     public double getWinterWeekElectricitySelfConsumed_MWh() {
-        return max(0, getWinterWeekElectricityConsumed_MWh() - am_winterWeekBalanceAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegralPos_MWh());
+        return max(0, getWinterWeekElectricityConsumed_MWh() - getWinterWeekImport_MWh(OL_EnergyCarriers.ELECTRICITY));
     }
     public double getWinterWeekEnergyConsumed_MWh() {
         return acc_winterWeekFinalEnergyConsumption_kW.getIntegral_MWh();
@@ -655,7 +655,7 @@ public class J_RapidRunData {
         return acc_daytimeElectricityProduction_kW.getIntegral_MWh(); 
     }
     public double getDaytimeElectricitySelfConsumed_MWh() { 
-        return max(0, getDaytimeElectricityConsumed_MWh() - am_daytimeImports_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh()); 
+        return max(0, getDaytimeElectricityConsumed_MWh() - getDaytimeImport_MWh(OL_EnergyCarriers.ELECTRICITY));
     }
     public double getDaytimeEnergyConsumed_MWh() { 
         return acc_daytimeFinalEnergyConsumption_kW.getIntegral_MWh(); 
@@ -695,7 +695,7 @@ public class J_RapidRunData {
         return getTotalElectricityProduced_MWh() - getDaytimeElectricityProduced_MWh(); 
     }
     public double getNighttimeElectricitySelfConsumed_MWh() { 
-        return max(0,getNighttimeElectricityConsumed_MWh() - (am_totalBalanceAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh() - am_daytimeImports_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh())); 
+        return max(0, getNighttimeElectricityConsumed_MWh() - getNighttimeImport_MWh(OL_EnergyCarriers.ELECTRICITY));
     }
     public double getNighttimeEnergyConsumed_MWh() { 
         return getTotalEnergyConsumed_MWh() - getDaytimeEnergyConsumed_MWh(); 
@@ -735,7 +735,7 @@ public class J_RapidRunData {
         return getTotalElectricityProduced_MWh() - getWeekendElectricityProduced_MWh(); 
     }
     public double getWeekdayElectricitySelfConsumed_MWh() { 
-        return max(0,getWeekdayElectricityConsumed_MWh() - (am_totalBalanceAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh() - am_weekendImports_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh())); 
+        return max(0, getWeekdayElectricityConsumed_MWh() - getWeekdayImport_MWh(OL_EnergyCarriers.ELECTRICITY));
     }
     public double getWeekdayEnergyConsumed_MWh() { 
         return getTotalEnergyConsumed_MWh() - getWeekendEnergyConsumed_MWh(); 
@@ -775,7 +775,7 @@ public class J_RapidRunData {
         return acc_weekendElectricityProduction_kW.getIntegral_MWh(); 
     }
     public double getWeekendElectricitySelfConsumed_MWh() { 
-        return max(0, getWeekendElectricityConsumed_MWh() - am_weekendImports_kW.get(OL_EnergyCarriers.ELECTRICITY).getIntegral_MWh()); 
+        return max(0, getWeekendElectricityConsumed_MWh() - getWeekendImport_MWh(OL_EnergyCarriers.ELECTRICITY));
     }
     public double getWeekendEnergyConsumed_MWh() { 
         return acc_weekendFinalEnergyConsumption_kW.getIntegral_MWh(); 


### PR DESCRIPTION
- Added accumulators for the primary energy production of heatpumps for weekend & daytime.
- Refactored the rapidrundata class to use the accumulator and accumulatormaps' get MWh methods.