### PR TITLE
Bugfix voor de energycarriers boekhouding in het model

### DIFF
--- a/_alp/Agents/ConnectionOwner/AOC.ConnectionOwner.xml
+++ b/_alp/Agents/ConnectionOwner/AOC.ConnectionOwner.xml
@@ -20,9 +20,6 @@
 		<Parameter>
 			<Name><![CDATA[p_actorGroup]]></Name>
 		</Parameter>
-		<Parameter>
-			<Name><![CDATA[b_dataSharingAgreed]]></Name>
-		</Parameter>
 	</Parameters>
 	<StartupCode><![CDATA[energyModel.c_actors.add(this);
 energyModel.c_connectionOwners.add(this);]]></StartupCode>

--- a/_alp/Agents/EnergyCoop/Code/Functions.java
+++ b/_alp/Agents/EnergyCoop/Code/Functions.java
@@ -1514,9 +1514,14 @@ double currentImport_kW = 0.0;
 double currentExport_kW = 0.0;
 for (OL_EnergyCarriers EC : v_activeEnergyCarriers) {
 	double currentBalance_kW = fm_currentBalanceFlows_kW.get(EC);
-	currentImport_kW += max( 0, currentBalance_kW );
-	currentExport_kW += max( 0, -currentBalance_kW );
 	v_rapidRunData.am_totalBalanceAccumulators_kW.get(EC).addStep(  currentBalance_kW );
+	
+	if(v_activeConsumptionEnergyCarriers.contains(EC)){
+		currentImport_kW += max( 0, currentBalance_kW );
+	}
+	if(v_activeProductionEnergyCarriers.contains(EC)){
+		currentExport_kW += max( 0, -currentBalance_kW );
+	}
 }
 
 // Daytime totals. Use overal-total minus daytime total to get nighttime totals.
@@ -1524,8 +1529,13 @@ if(energyModel.b_isDaytime) {
 	
 	for (OL_EnergyCarriers EC : v_activeEnergyCarriers) {
 		double currentBalance_kW = fm_currentBalanceFlows_kW.get(EC);
-		v_rapidRunData.am_daytimeImports_kW.get(EC).addStep(max( 0, currentBalance_kW ));
-		v_rapidRunData.am_daytimeExports_kW.get(EC).addStep(max( 0, -currentBalance_kW ));
+
+		if(v_activeConsumptionEnergyCarriers.contains(EC)){
+			v_rapidRunData.am_daytimeImports_kW.get(EC).addStep(max( 0, currentBalance_kW ));
+		}
+		if(v_activeProductionEnergyCarriers.contains(EC)){
+			v_rapidRunData.am_daytimeExports_kW.get(EC).addStep(max( 0, -currentBalance_kW ));
+		}
 	}
 	
 	v_rapidRunData.acc_daytimeElectricityProduction_kW.addStep(fm_currentProductionFlows_kW.get(OL_EnergyCarriers.ELECTRICITY) );
@@ -1539,8 +1549,13 @@ if(energyModel.b_isDaytime) {
 if (!energyModel.b_isWeekday) { // 
 	for (OL_EnergyCarriers EC : v_activeEnergyCarriers) {
 		double currentBalance_kW = fm_currentBalanceFlows_kW.get(EC);
-		v_rapidRunData.am_weekendImports_kW.get(EC).addStep(max( 0, currentBalance_kW ));
-		v_rapidRunData.am_weekendExports_kW.get(EC).addStep(max( 0, -currentBalance_kW ));
+
+		if(v_activeConsumptionEnergyCarriers.contains(EC)){
+			v_rapidRunData.am_weekendImports_kW.get(EC).addStep(max( 0, currentBalance_kW ));
+		}
+		if(v_activeProductionEnergyCarriers.contains(EC)){
+			v_rapidRunData.am_weekendExports_kW.get(EC).addStep(max( 0, -currentBalance_kW ));
+		}
 	}
 	
 	v_rapidRunData.acc_weekendElectricityProduction_kW.addStep(fm_currentProductionFlows_kW.get(OL_EnergyCarriers.ELECTRICITY) );

--- a/_alp/Agents/EnergyModel/Code/Functions.xml
+++ b/_alp/Agents/EnergyModel/Code/Functions.xml
@@ -634,7 +634,7 @@
 		<ReturnModificator>VOID</ReturnModificator>
 		<ReturnType>EnergyCoop</ReturnType>
 		<Id>1740056275008</Id>
-		<Name><![CDATA[f_addEnergyCarrier]]></Name>
+		<Name><![CDATA[f_addConsumptionEnergyCarrier]]></Name>
 		<X>1680</X>
 		<Y>580</Y>
 		<Label>
@@ -680,6 +680,26 @@
 		<PublicFlag>false</PublicFlag>
 		<PresentationFlag>true</PresentationFlag>
 		<ShowLabel>true</ShowLabel>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
+	<Function AccessType="public" StaticFunction="false">
+		<ReturnModificator>VOID</ReturnModificator>
+		<ReturnType>EnergyCoop</ReturnType>
+		<Id>1746021439807</Id>
+		<Name><![CDATA[f_addProductionEnergyCarrier]]></Name>
+		<X>1680</X>
+		<Y>600</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Parameter>
+			<Name><![CDATA[EC]]></Name>
+			<Type><![CDATA[OL_EnergyCarriers]]></Type>
+		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
 </Functions>

--- a/_alp/Agents/GCNeighborhood/Code/Functions.java
+++ b/_alp/Agents/GCNeighborhood/Code/Functions.java
@@ -288,34 +288,46 @@ if (j_ea instanceof J_EAVehicle) {
 
 double f_connectToJ_EA_default_overwrite(J_EA j_ea)
 {/*ALCODESTART::1730370456790*/
-for (OL_EnergyCarriers EC : j_ea.getActiveEnergyCarriers()) {
-	if (!v_activeEnergyCarriers.contains(EC)) {
+for (OL_EnergyCarriers EC : j_ea.getActiveConsumptionEnergyCarriers()) {
+	if (!v_activeConsumptionEnergyCarriers.contains(EC)) {
 		v_activeEnergyCarriers.add(EC);
-		
+		v_activeConsumptionEnergyCarriers.add(EC);
+			
 		if (energyModel.b_isInitialized) {
-			energyModel.f_addEnergyCarrier(EC);
+			//Add EC to energyModel
+			energyModel.f_addConsumptionEnergyCarrier(EC);
+			
+			//Initialize dataset
 			DataSet dsDemand = new DataSet( (int)(168 / energyModel.p_timeStep_h) );
-			DataSet dsSupply = new DataSet( (int)(168 / energyModel.p_timeStep_h) );
 			double startTime = v_liveData.dsm_liveDemand_kW.get(OL_EnergyCarriers.ELECTRICITY).getXMin();
 			double endTime = v_liveData.dsm_liveDemand_kW.get(OL_EnergyCarriers.ELECTRICITY).getXMax();
 			for (double t = startTime; t <= endTime; t += energyModel.p_timeStep_h) {
 				dsDemand.add( t, 0);
-				dsSupply.add( t, 0);
 			}
 			v_liveData.dsm_liveDemand_kW.put( EC, dsDemand);
-			v_liveData.dsm_liveSupply_kW.put( EC, dsSupply);
 		}
 	}
 }
 
-//Production EC
-for(OL_EnergyCarriers EC_production : j_ea.getActiveProductionEnergyCarriers()){
-	v_activeProductionEnergyCarriers.add(EC_production);
-}
-
-//Consumption EC
-for(OL_EnergyCarriers EC_consumption : j_ea.getActiveConsumptionEnergyCarriers()){
-	v_activeConsumptionEnergyCarriers.add(EC_consumption);
+for (OL_EnergyCarriers EC : j_ea.getActiveProductionEnergyCarriers()) {
+	if (!v_activeProductionEnergyCarriers.contains(EC)) {
+		v_activeEnergyCarriers.add(EC);
+		v_activeProductionEnergyCarriers.add(EC);		
+		if (energyModel.b_isInitialized) {
+		
+			//Add EC to energyModel
+			energyModel.f_addProductionEnergyCarrier(EC);
+			
+			//Initialize datasets
+			DataSet dsSupply = new DataSet( (int)(168 / energyModel.p_timeStep_h) );
+			double startTime = v_liveData.dsm_liveDemand_kW.get(OL_EnergyCarriers.ELECTRICITY).getXMin();
+			double endTime = v_liveData.dsm_liveDemand_kW.get(OL_EnergyCarriers.ELECTRICITY).getXMax();
+			for (double t = startTime; t <= endTime; t += energyModel.p_timeStep_h) {
+				dsSupply.add( t, 0);
+			}
+			v_liveData.dsm_liveSupply_kW.put( EC, dsSupply);
+		}
+	}
 }
 
 

--- a/_alp/Classes/Class.J_RapidRunData.java
+++ b/_alp/Classes/Class.J_RapidRunData.java
@@ -129,14 +129,14 @@ public class J_RapidRunData {
     }
     
     public void initializeAccumulators(double simDuration_h, double timeStep_h, EnumSet<OL_EnergyCarriers> v_activeEnergyCarriers, EnumSet<OL_EnergyCarriers> v_activeConsumptionEnergyCarriers, EnumSet<OL_EnergyCarriers> v_activeProductionEnergyCarriers) {
-    	this.activeEnergyCarriers = v_activeEnergyCarriers;
-    	this.activeConsumptionEnergyCarriers = v_activeConsumptionEnergyCarriers;
-    	this.activeProductionEnergyCarriers = v_activeProductionEnergyCarriers;
+    	this.activeEnergyCarriers = EnumSet.copyOf(v_activeEnergyCarriers);
+    	this.activeConsumptionEnergyCarriers = EnumSet.copyOf(v_activeConsumptionEnergyCarriers);
+    	this.activeProductionEnergyCarriers = EnumSet.copyOf(v_activeProductionEnergyCarriers);
 	    //========== TOTAL ACCUMULATORS ==========//
-		am_totalBalanceAccumulators_kW.createEmptyAccumulators( v_activeEnergyCarriers, true, 24.0, simDuration_h );
+		am_totalBalanceAccumulators_kW.createEmptyAccumulators( this.activeEnergyCarriers, true, 24.0, simDuration_h );
 	    am_totalBalanceAccumulators_kW.put( OL_EnergyCarriers.ELECTRICITY, new ZeroAccumulator(true, timeStep_h, simDuration_h) );
-	    am_dailyAverageConsumptionAccumulators_kW.createEmptyAccumulators(v_activeConsumptionEnergyCarriers, true, 24.0, simDuration_h);
-	    am_dailyAverageProductionAccumulators_kW.createEmptyAccumulators(v_activeProductionEnergyCarriers, true, 24.0, simDuration_h);
+	    am_dailyAverageConsumptionAccumulators_kW.createEmptyAccumulators(this.activeConsumptionEnergyCarriers, true, 24.0, simDuration_h);
+	    am_dailyAverageProductionAccumulators_kW.createEmptyAccumulators(this.activeProductionEnergyCarriers, true, 24.0, simDuration_h);
 	
 	    acc_dailyAverageEnergyProduction_kW = new ZeroAccumulator(true, 24.0, simDuration_h);
 	    acc_dailyAverageFinalEnergyConsumption_kW = new ZeroAccumulator(true, 24.0, simDuration_h);
@@ -162,9 +162,9 @@ public class J_RapidRunData {
 	    ts_dailyAverageBatteriesSOC_fr = new ZeroTimeSeries(24.0, simDuration_h);
 	    
 	    //========== SUMMER WEEK ACCUMULATORS ==========//
-	    am_summerWeekBalanceAccumulators_kW.createEmptyAccumulators(v_activeEnergyCarriers, true, timeStep_h, 168.0);
-	    am_summerWeekConsumptionAccumulators_kW.createEmptyAccumulators(v_activeEnergyCarriers, true, timeStep_h, 168.0);
-	    am_summerWeekProductionAccumulators_kW.createEmptyAccumulators(v_activeEnergyCarriers, true, timeStep_h, 168.0);
+	    am_summerWeekBalanceAccumulators_kW.createEmptyAccumulators(this.activeEnergyCarriers, true, timeStep_h, 168.0);
+	    am_summerWeekConsumptionAccumulators_kW.createEmptyAccumulators(this.activeConsumptionEnergyCarriers, true, timeStep_h, 168.0);
+	    am_summerWeekProductionAccumulators_kW.createEmptyAccumulators(this.activeProductionEnergyCarriers, true, timeStep_h, 168.0);
 	
 	    acc_summerWeekEnergyProduction_kW = new ZeroAccumulator(true, timeStep_h, 168.0);
 	    acc_summerWeekFinalEnergyConsumption_kW = new ZeroAccumulator(true, timeStep_h, 168.0);
@@ -193,9 +193,9 @@ public class J_RapidRunData {
 	    ts_summerWeekBatteriesSOC_fr = new ZeroTimeSeries(timeStep_h, 168.0);
 	    
 	    //========== WINTER WEEK ACCUMULATORS ==========//
-	    am_winterWeekBalanceAccumulators_kW.createEmptyAccumulators(v_activeEnergyCarriers, true, timeStep_h, 168.0);
-	    am_winterWeekConsumptionAccumulators_kW.createEmptyAccumulators(v_activeEnergyCarriers, true, timeStep_h, 168.0);
-	    am_winterWeekProductionAccumulators_kW.createEmptyAccumulators(v_activeEnergyCarriers, true, timeStep_h, 168.0);
+	    am_winterWeekBalanceAccumulators_kW.createEmptyAccumulators(this.activeEnergyCarriers, true, timeStep_h, 168.0);
+	    am_winterWeekConsumptionAccumulators_kW.createEmptyAccumulators(this.activeConsumptionEnergyCarriers, true, timeStep_h, 168.0);
+	    am_winterWeekProductionAccumulators_kW.createEmptyAccumulators(this.activeProductionEnergyCarriers, true, timeStep_h, 168.0);
 	
 	    acc_winterWeekEnergyProduction_kW = new ZeroAccumulator(true, timeStep_h, 168.0);
 	    acc_winterWeekFinalEnergyConsumption_kW = new ZeroAccumulator(true, timeStep_h, 168.0);
@@ -224,8 +224,8 @@ public class J_RapidRunData {
 	    ts_winterWeekBatteriesSOC_fr = new ZeroTimeSeries(timeStep_h, 168.0);
 	    
 	    //========== DAYTIME ACCUMULATORS ==========//
-	    am_daytimeImports_kW.createEmptyAccumulators( v_activeEnergyCarriers, false, timeStep_h, 0.5 * (simDuration_h));
-	    am_daytimeExports_kW.createEmptyAccumulators( v_activeEnergyCarriers, false, timeStep_h, 0.5 * (simDuration_h));
+	    am_daytimeImports_kW.createEmptyAccumulators( this.activeConsumptionEnergyCarriers, false, timeStep_h, 0.5 * (simDuration_h));
+	    am_daytimeExports_kW.createEmptyAccumulators( this.activeProductionEnergyCarriers, false, timeStep_h, 0.5 * (simDuration_h));
 	
 	    acc_daytimeEnergyProduction_kW = new ZeroAccumulator(false, timeStep_h, 0.5 * (simDuration_h));
 	    acc_daytimeFinalEnergyConsumption_kW = new ZeroAccumulator(false, timeStep_h,0.5 * (simDuration_h));
@@ -236,8 +236,8 @@ public class J_RapidRunData {
 	    acc_daytimePrimaryEnergyProductionHeatpumps_kW = new ZeroAccumulator(false, timeStep_h, 0.5 * (simDuration_h));
 	    		
 	    //========== WEEKEND ACCUMULATORS ==========//
-	    am_weekendImports_kW.createEmptyAccumulators( v_activeEnergyCarriers, false, timeStep_h, 2 / 7  * (simDuration_h) + 48);
-	    am_weekendExports_kW.createEmptyAccumulators( v_activeEnergyCarriers, false, timeStep_h, 2 / 7 * (simDuration_h) + 48);
+	    am_weekendImports_kW.createEmptyAccumulators( this.activeConsumptionEnergyCarriers, false, timeStep_h, 2 / 7  * (simDuration_h) + 48);
+	    am_weekendExports_kW.createEmptyAccumulators( this.activeProductionEnergyCarriers, false, timeStep_h, 2 / 7 * (simDuration_h) + 48);
 	
 	    acc_weekendEnergyProduction_kW = new ZeroAccumulator(false, timeStep_h, 2 / 7  * (simDuration_h) + 48);
 	    acc_weekendFinalEnergyConsumption_kW = new ZeroAccumulator(false, timeStep_h,2 / 7  * (simDuration_h) + 48);
@@ -249,14 +249,14 @@ public class J_RapidRunData {
     }
 
     public void resetAccumulators(double simDuration_h, double timeStep_h, EnumSet<OL_EnergyCarriers> v_activeEnergyCarriers, EnumSet<OL_EnergyCarriers> v_activeConsumptionEnergyCarriers, EnumSet<OL_EnergyCarriers> v_activeProductionEnergyCarriers) {
-    	this.activeEnergyCarriers = v_activeEnergyCarriers;
-    	this.activeConsumptionEnergyCarriers = v_activeConsumptionEnergyCarriers;
-    	this.activeProductionEnergyCarriers = v_activeProductionEnergyCarriers;
+    	this.activeEnergyCarriers = EnumSet.copyOf(v_activeEnergyCarriers);
+    	this.activeConsumptionEnergyCarriers = EnumSet.copyOf(v_activeConsumptionEnergyCarriers);
+    	this.activeProductionEnergyCarriers = EnumSet.copyOf(v_activeProductionEnergyCarriers);
     	//Total simulation
-		am_totalBalanceAccumulators_kW.createEmptyAccumulators( v_activeEnergyCarriers, true, 24.0, simDuration_h );
+		am_totalBalanceAccumulators_kW.createEmptyAccumulators( this.activeEnergyCarriers, true, 24.0, simDuration_h );
     	am_totalBalanceAccumulators_kW.put( OL_EnergyCarriers.ELECTRICITY, new ZeroAccumulator(true, timeStep_h, simDuration_h) );
-    	am_dailyAverageConsumptionAccumulators_kW.createEmptyAccumulators(v_activeConsumptionEnergyCarriers, true, 24.0, simDuration_h);
-    	am_dailyAverageProductionAccumulators_kW.createEmptyAccumulators(v_activeProductionEnergyCarriers, true, 24.0, simDuration_h);
+    	am_dailyAverageConsumptionAccumulators_kW.createEmptyAccumulators(this.activeConsumptionEnergyCarriers, true, 24.0, simDuration_h);
+    	am_dailyAverageProductionAccumulators_kW.createEmptyAccumulators(this.activeProductionEnergyCarriers, true, 24.0, simDuration_h);
 
     	acc_dailyAverageEnergyProduction_kW.reset();
     	acc_dailyAverageFinalEnergyConsumption_kW.reset();
@@ -282,9 +282,9 @@ public class J_RapidRunData {
         ts_dailyAverageBatteriesSOC_fr.reset();
         
     	//Summerweek
-    	am_summerWeekBalanceAccumulators_kW.createEmptyAccumulators(v_activeEnergyCarriers, true, timeStep_h, 24*7);
-    	am_summerWeekConsumptionAccumulators_kW.createEmptyAccumulators(v_activeEnergyCarriers, true, timeStep_h, 24*7);
-    	am_summerWeekProductionAccumulators_kW.createEmptyAccumulators(v_activeEnergyCarriers, true, timeStep_h, 24*7);
+    	am_summerWeekBalanceAccumulators_kW.createEmptyAccumulators(this.activeEnergyCarriers, true, timeStep_h, 24*7);
+    	am_summerWeekConsumptionAccumulators_kW.createEmptyAccumulators(this.activeConsumptionEnergyCarriers, true, timeStep_h, 24*7);
+    	am_summerWeekProductionAccumulators_kW.createEmptyAccumulators(this.activeProductionEnergyCarriers, true, timeStep_h, 24*7);
 
     	acc_summerWeekEnergyProduction_kW.reset();
     	acc_summerWeekFinalEnergyConsumption_kW.reset();
@@ -314,8 +314,8 @@ public class J_RapidRunData {
 	    
     	//Winterweek
     	am_winterWeekBalanceAccumulators_kW.createEmptyAccumulators(v_activeEnergyCarriers, true, timeStep_h, 24*7);
-    	am_winterWeekConsumptionAccumulators_kW.createEmptyAccumulators(v_activeEnergyCarriers, true, timeStep_h, 24*7);
-    	am_winterWeekProductionAccumulators_kW.createEmptyAccumulators(v_activeEnergyCarriers, true, timeStep_h, 24*7);
+    	am_winterWeekConsumptionAccumulators_kW.createEmptyAccumulators(this.activeConsumptionEnergyCarriers, true, timeStep_h, 24*7);
+    	am_winterWeekProductionAccumulators_kW.createEmptyAccumulators(this.activeProductionEnergyCarriers, true, timeStep_h, 24*7);
 
     	acc_winterWeekEnergyProduction_kW.reset();
     	acc_winterWeekFinalEnergyConsumption_kW.reset();
@@ -344,8 +344,8 @@ public class J_RapidRunData {
 	    ts_winterWeekBatteriesSOC_fr.reset();
 	    
     	// Daytime 
-    	am_daytimeImports_kW.createEmptyAccumulators( v_activeEnergyCarriers, false, timeStep_h, 0.5 * (simDuration_h));
-    	am_daytimeExports_kW.createEmptyAccumulators( v_activeEnergyCarriers, false, timeStep_h, 0.5 * (simDuration_h));
+    	am_daytimeImports_kW.createEmptyAccumulators( this.activeConsumptionEnergyCarriers, false, timeStep_h, 0.5 * (simDuration_h));
+    	am_daytimeExports_kW.createEmptyAccumulators( this.activeProductionEnergyCarriers, false, timeStep_h, 0.5 * (simDuration_h));
     	
     	acc_daytimeElectricityProduction_kW.reset();
     	acc_daytimeElectricityConsumption_kW.reset();
@@ -355,8 +355,8 @@ public class J_RapidRunData {
     	acc_daytimePrimaryEnergyProductionHeatpumps_kW.reset();
     	
     	// Weekend
-    	am_weekendImports_kW.createEmptyAccumulators( v_activeEnergyCarriers, false, timeStep_h, 2 / 7  * (simDuration_h) + 48);
-    	am_weekendExports_kW.createEmptyAccumulators( v_activeEnergyCarriers, false, timeStep_h, 2 / 7 * (simDuration_h) + 48);
+    	am_weekendImports_kW.createEmptyAccumulators( this.activeConsumptionEnergyCarriers, false, timeStep_h, 2 / 7  * (simDuration_h) + 48);
+    	am_weekendExports_kW.createEmptyAccumulators( this.activeProductionEnergyCarriers, false, timeStep_h, 2 / 7 * (simDuration_h) + 48);
 
     	acc_weekendElectricityProduction_kW.reset();
     	acc_weekendElectricityConsumption_kW.reset();


### PR DESCRIPTION
Tijdens de model simulatie het is nu mogelijk om compleet nieuwe energy carriers toe te voegen. Door middel van bijvoorbeeld het toevoegen van een waterstof auto voordat er waterstof consumptie was. Verder andere boekhouding bugs opgelost.