### PR TITLE
bugfixes for when a coop is made using the filter functionality

### DIFF
--- a/_alp/Agents/EnergyCoop/Code/Functions.java
+++ b/_alp/Agents/EnergyCoop/Code/Functions.java
@@ -1562,7 +1562,7 @@ for(GridConnection GC : c_memberGridConnections){
 
 //Adjust StoreTotalAssetFlows accordingly to the member data
 v_rapidRunData.setStoreTotalAssetFlows(storeTotalAssetFlows);
-traceln("v_rapidRunData.setStoreTotalAssetFlows: " + v_rapidRunData.getStoreTotalAssetFlows());
+
 //For now assumed to stay the same even after slider change: can't see rapid run graphs anyway after slider change
 v_rapidRunData.connectionMetaData = v_liveConnectionMetaData.getClone();
 

--- a/_alp/Agents/EnergyCoop/Code/Functions.xml
+++ b/_alp/Agents/EnergyCoop/Code/Functions.xml
@@ -349,7 +349,7 @@
 		<Id>1739970817879</Id>
 		<Name><![CDATA[f_collectGridConnectionRapidRunData]]></Name>
 		<X>990</X>
-		<Y>210</Y>
+		<Y>230</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -520,22 +520,6 @@
 	<Function AccessType="public" StaticFunction="false">
 		<ReturnModificator>VOID</ReturnModificator>
 		<ReturnType>double</ReturnType>
-		<Id>1740502128178</Id>
-		<Name><![CDATA[f_collectAssetSpecificEnergyFlows_rapidRun]]></Name>
-		<X>1010</X>
-		<Y>230</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Body xmlns:al="http://anylogic.com"/>
-	</Function>
-	<Function AccessType="public" StaticFunction="false">
-		<ReturnModificator>VOID</ReturnModificator>
-		<ReturnType>double</ReturnType>
 		<Id>1740502128180</Id>
 		<Name><![CDATA[f_collectGridConnectionLiveData]]></Name>
 		<X>990</X>
@@ -572,23 +556,6 @@
 		<Name><![CDATA[f_connectCoopBattery]]></Name>
 		<X>990</X>
 		<Y>300</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Body xmlns:al="http://anylogic.com"/>
-	</Function>
-	<Function AccessType="default" StaticFunction="false">
-		<ReturnModificator>VOID</ReturnModificator>
-		<ReturnType>double</ReturnType>
-		<Id>1744211126429</Id>
-		<Name><![CDATA[f_recalculateSOC_rapidrun]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>1010</X>
-		<Y>270</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -704,6 +671,22 @@
 			<Name><![CDATA[AC]]></Name>
 			<Type><![CDATA[OL_AssetFlowCategories]]></Type>
 		</Parameter>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
+	<Function AccessType="default" StaticFunction="false">
+		<ReturnModificator>VOID</ReturnModificator>
+		<ReturnType>double</ReturnType>
+		<Id>1754666678297</Id>
+		<Name><![CDATA[f_createAndInitializeRapidRunDataClass]]></Name>
+		<X>990</X>
+		<Y>210</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
 </Functions>

--- a/_alp/Agents/EnergyModel/Code/Functions.java
+++ b/_alp/Agents/EnergyModel/Code/Functions.java
@@ -287,6 +287,10 @@ for (EnergyCoop EC : pop_energyCoops) {
 		}
 		EC.v_rapidRunData.assetsMetaData = EC.v_liveAssetsMetaData.getClone();
 		EC.v_rapidRunData.connectionMetaData = EC.v_liveConnectionMetaData.getClone();
+		if(EC.v_rapidRunData.getStoreTotalAssetFlows() == false){
+			EC.v_rapidRunData.setStoreTotalAssetFlows(true);
+			EC.v_rapidRunData.initializeAccumulators(p_runEndTime_h - p_runStartTime_h, p_timeStep_h, EC.v_activeEnergyCarriers, EC.v_activeConsumptionEnergyCarriers, EC.v_activeProductionEnergyCarriers);
+		}
 	} else {
 		EC.v_rapidRunData = new J_RapidRunData(EC);
 		EC.v_rapidRunData.assetsMetaData = EC.v_liveAssetsMetaData.getClone();

--- a/_alp/Classes/Class.J_RapidRunData.java
+++ b/_alp/Classes/Class.J_RapidRunData.java
@@ -6,7 +6,7 @@ import zeroPackage.ZeroMath;
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
 @JsonIgnoreType
 public class J_RapidRunData {
-	public boolean storesTotalAssetFlows = true;
+	private boolean storeTotalAssetFlows = true;
 	public Agent parentAgent;
 	private double timeStep_h;
 	public EnumSet<OL_EnergyCarriers> activeEnergyCarriers;
@@ -98,10 +98,18 @@ public class J_RapidRunData {
     public J_RapidRunData(Agent parentAgent) {
     	this.parentAgent = parentAgent;
     	if (parentAgent instanceof GridConnection) {
-    		if (!((GridConnection)parentAgent).v_hasQuarterHourlyValues ) {
-    			storesTotalAssetFlows = false;
+    		if (!((GridConnection)parentAgent).p_owner.p_detailedCompany ) {
+    			storeTotalAssetFlows = false;
     		}
     	}
+    }
+    
+    public void setStoreTotalAssetFlows(boolean storeTotalAssetFlows) {
+    	this.storeTotalAssetFlows = storeTotalAssetFlows;
+    }
+    
+    public boolean getStoreTotalAssetFlows() {
+    	return this.storeTotalAssetFlows;
     }
     
     public void initializeAccumulators(double simDuration_h, double timeStep_h, EnumSet<OL_EnergyCarriers> v_activeEnergyCarriers, EnumSet<OL_EnergyCarriers> v_activeConsumptionEnergyCarriers, EnumSet<OL_EnergyCarriers> v_activeProductionEnergyCarriers) {
@@ -122,7 +130,7 @@ public class J_RapidRunData {
 	    acc_totalPrimaryEnergyProductionHeatpumps_kW = new ZeroAccumulator(true, 24.0, simDuration_h);
 	
 	    //========== ASSET FLOWS ==========//
-	    if (storesTotalAssetFlows) {
+	    if (storeTotalAssetFlows) {
 	    	am_assetFlowsAccumulators_kW.createEmptyAccumulators( this.assetsMetaData.activeAssetFlows, true, timeStep_h, simDuration_h);
 	    	if (this.assetsMetaData.activeAssetFlows.contains(OL_AssetFlowCategories.batteriesChargingPower_kW)) {
 		    	ts_dailyAverageBatteriesStoredEnergy_MWh = new ZeroTimeSeries(timeStep_h, simDuration_h);
@@ -137,8 +145,6 @@ public class J_RapidRunData {
 	    		ts_dailyAverageBatteriesStoredEnergy_MWh = new ZeroTimeSeries(simDuration_h, simDuration_h);	    		
 	    	}
 	    }	  
-
-	    //ts_dailyAverageBatteriesSOC_fr = new ZeroTimeSeries(24.0, simDuration_h);
 	    
 	    //========== SUMMER WEEK ACCUMULATORS ==========//
 	    am_summerWeekBalanceAccumulators_kW.createEmptyAccumulators(this.activeEnergyCarriers, true, timeStep_h, 168.0);
@@ -217,14 +223,13 @@ public class J_RapidRunData {
     	acc_totalEnergyCurtailed_kW.reset();
     	acc_totalPrimaryEnergyProductionHeatpumps_kW.reset();
 
-    	if (storesTotalAssetFlows) {
+    	if (storeTotalAssetFlows) {
   	    	am_assetFlowsAccumulators_kW.createEmptyAccumulators( this.assetsMetaData.activeAssetFlows, true, timeStep_h, simDuration_h);
   	    } else {
   	    	am_assetFlowsAccumulators_kW.createEmptyAccumulators( this.assetsMetaData.activeAssetFlows, true, 24.0, simDuration_h);	
   	    }
 
         ts_dailyAverageBatteriesStoredEnergy_MWh.reset();
-        //ts_dailyAverageBatteriesSOC_fr.reset();
         
     	//Summerweek
     	am_summerWeekBalanceAccumulators_kW.createEmptyAccumulators(this.activeEnergyCarriers, true, timeStep_h, 24*7);

--- a/_alp/Classes/Class.J_RapidRunData.java
+++ b/_alp/Classes/Class.J_RapidRunData.java
@@ -98,14 +98,15 @@ public class J_RapidRunData {
     public J_RapidRunData(Agent parentAgent) {
     	this.parentAgent = parentAgent;
     	if (parentAgent instanceof GridConnection) {
-    		if (!((GridConnection)parentAgent).p_owner.p_detailedCompany ) {
+    		if (!((GridConnection)parentAgent).p_owner.p_detailedCompany && !((GridConnection)parentAgent).v_hasQuarterHourlyValues) {
     			storeTotalAssetFlows = false;
     		}
     	}
     }
     
-    public void setStoreTotalAssetFlows(boolean storeTotalAssetFlows) {
+    public boolean setStoreTotalAssetFlows(boolean storeTotalAssetFlows) {
     	this.storeTotalAssetFlows = storeTotalAssetFlows;
+    	return this.storeTotalAssetFlows == storeTotalAssetFlows; // Check if it has succeeded (Always for now!)
     }
     
     public boolean getStoreTotalAssetFlows() {


### PR DESCRIPTION
Added a functionality to the accumulator.add method. Where it is now also possible to add an accumulator with a smaller resolution to an accumulator with a larger resolution if it matches time intervals. The data resolution of the rapid run class of the  coop after creation is now equal to the largest interval of the members. When a coop is present during rapid run sim, the resolution of the coop is converted into more detail again.