### PR TITLE
New overload to getDataSet method

### DIFF
--- a/_alp/Classes/Class.J_AccumulatorMap.java
+++ b/_alp/Classes/Class.J_AccumulatorMap.java
@@ -136,6 +136,14 @@ public class J_AccumulatorMap <E extends Enum<E>> implements Serializable {
 		return dsm;
 	}
 	
+	public J_DataSetMap getDataSetMap( double startTime_h, double dataSetSignalResolution_h ) {
+		J_DataSetMap dsm = new J_DataSetMap(this.enumClass);
+		for (var EC : this.enumSet) {
+			dsm.put(EC, this.get(EC).getDataSet(startTime_h, dataSetSignalResolution_h));
+		}
+		return dsm;
+	}
+	
     public String toString() {
         if (this.accumulatorArray.length == 0) {
             return "{}";        	

--- a/_alp/Classes/Class.ZeroAccumulator.java
+++ b/_alp/Classes/Class.ZeroAccumulator.java
@@ -323,6 +323,32 @@ public class ZeroAccumulator {
     	}
     }
 	
+    public DataSet getDataSet(double startTime_h, double dataSetSignalResolution_h) {
+    	if (this.hasTimeSeries) {
+    		if (dataSetSignalResolution_h % this.signalResolution_h == 0) {
+    			int accumulatorEntries = roundToInt(dataSetSignalResolution_h / this.signalResolution_h); // number of entries in accumulator per dataset entry
+    			if (duration_h % dataSetSignalResolution_h == 0) {
+    				int dataSetSize = roundToInt(duration_h / dataSetSignalResolution_h);
+            		DataSet ds = new DataSet(dataSetSize);
+        			for (int i = 0; i < dataSetSize; i++) {
+        				double value = 0;
+        				for (int j = 0; j < accumulatorEntries; j++) {
+        					value += this.timeSeries[accumulatorEntries * i + j];
+        				}
+        				value /= accumulatorEntries;
+        				ds.add(startTime_h + i * dataSetSignalResolution_h, roundToDecimal(value,3) );
+        			}
+        			return ds;
+    			} else {
+    				throw new RuntimeException("Impossible to create DataSet from accumulator: signal resolution does not divide into timeseries");
+    			}
+    		} else {
+    			throw new RuntimeException("Impossible to create DataSet from accumulator with signal resolution that is not a multiple of the accumulator's signal resolution.");
+    		}
+    	} else {
+    		throw new RuntimeException("Impossible to create DataSet from accumulator without timeSeries.");    		
+    	}
+    }
     public DataSet getDataSet(double startTime_h, double accStartTime_h, double accEndTime_h) {
     	
     	double dataSetDuration_h = accEndTime_h - accStartTime_h;


### PR DESCRIPTION
The new method allows you to specify the resolution of the dataset. It must be a multiple of the resolution of the accumulator and a divisor of the duration. Currently used to plot the daily averages when the accumulator saves all datapoints