### PR TITLE
Small update to EnergyDataViewer

### DIFF
--- a/_alp/Agents/EnergyDataViewer/Code/Functions.java
+++ b/_alp/Agents/EnergyDataViewer/Code/Functions.java
@@ -53,32 +53,34 @@ for (GridConnection GC : energyModel.f_getGridConnections()){
 
 double f_fillEnergyDataViewer(I_EnergyData data)
 {/*ALCODESTART::1741792546533*/
-v_engineAgent = data.getRapidRunData().parentAgent;
-//Number of connected gcs
-//v_numberOfGridconnections = 1;
+v_engineAgent = data;
 
-//Set active energyCarriers
-v_activeConsumptionEnergyCarriers = data.getLiveData().activeConsumptionEnergyCarriers;
-v_activeProductionEnergyCarriers = data.getLiveData().activeProductionEnergyCarriers;
-
-//Update active asset booleans
-//f_updateLiveActiveAssetBooleans(data);
-v_activeAssetFlows = data.getLiveData().assetsMetaData.activeAssetFlows;
-
-//Update variables
-f_updateVariables(data);
+//Set live and rapidrun EnumSets for EnergyCarriers and AssetFlowCategories
+v_liveConsumptionEnergyCarriers = data.getLiveData().activeConsumptionEnergyCarriers;
+v_liveProductionEnergyCarriers = data.getLiveData().activeProductionEnergyCarriers;
+v_liveAssetFlowCategories = data.getLiveData().assetsMetaData.activeAssetFlows;
 
 //Update variables
 f_updateLiveDatasets(data);
 
-//Update variables
-f_updateWeeklyDatasets(data);
+if (data.getRapidRunData() != null) {
+	v_rapidRunConsumptionEnergyCarriers = data.getRapidRunData().activeConsumptionEnergyCarriers;
+	v_rapidRunProductionEnergyCarriers = data.getRapidRunData().activeProductionEnergyCarriers;
+	v_rapidRunAssetFlowCategories = data.getRapidRunData().assetsMetaData.activeAssetFlows;
 
-//Update variables
-f_updateYearlyDatasets(data);
+	//Update variables
+	f_updateVariables(data);
+	
+	//Update variables
+	f_updateWeeklyDatasets(data);
+	
+	//Update variables
+	f_updateYearlyDatasets(data);
+	
+	//Get duurkromme
+	f_updateLoadDurationCurve(data);
+}
 
-//Get duurkromme
-f_updateLoadDurationCurve(data);
 /*ALCODEEND*/}
 
 double f_updateVariables(I_EnergyData data)
@@ -112,10 +114,10 @@ v_individualPeakFeedin_kW = data.getRapidRunData().getPeakFeedin_kW();
 fm_totalImports_MWh.clear();
 fm_totalExports_MWh.clear();
 
-for (OL_EnergyCarriers energyCarrier : v_activeConsumptionEnergyCarriers) {
+for (OL_EnergyCarriers energyCarrier : data.getRapidRunData().activeConsumptionEnergyCarriers) {
 	fm_totalImports_MWh.put( energyCarrier, data.getRapidRunData().getTotalImport_MWh(energyCarrier) );
 }
-for (OL_EnergyCarriers energyCarrier : v_activeProductionEnergyCarriers) {
+for (OL_EnergyCarriers energyCarrier : data.getRapidRunData().activeProductionEnergyCarriers) {
 	fm_totalExports_MWh.put( energyCarrier, data.getRapidRunData().getTotalExport_MWh(energyCarrier) );
 }
 
@@ -142,11 +144,11 @@ fm_winterWeekImports_MWh.clear();
 fm_summerWeekExports_MWh.clear();
 fm_winterWeekExports_MWh.clear();
 
-for (OL_EnergyCarriers energyCarrier : v_activeConsumptionEnergyCarriers) {
+for (OL_EnergyCarriers energyCarrier : data.getRapidRunData().activeConsumptionEnergyCarriers) {
 	fm_summerWeekImports_MWh.put( energyCarrier, data.getRapidRunData().getSummerWeekImport_MWh(energyCarrier) );
 	fm_winterWeekImports_MWh.put( energyCarrier, data.getRapidRunData().getWinterWeekImport_MWh(energyCarrier) );
 }
-for (OL_EnergyCarriers energyCarrier : v_activeProductionEnergyCarriers) {
+for (OL_EnergyCarriers energyCarrier : data.getRapidRunData().activeProductionEnergyCarriers) {
 	fm_summerWeekExports_MWh.put( energyCarrier, data.getRapidRunData().getSummerWeekExport_MWh(energyCarrier) );
 	fm_winterWeekExports_MWh.put( energyCarrier, data.getRapidRunData().getWinterWeekExport_MWh(energyCarrier) );
 }
@@ -183,11 +185,11 @@ fm_nighttimeImports_MWh.clear();
 fm_daytimeExports_MWh.clear();
 fm_nighttimeExports_MWh.clear();
 
-for (OL_EnergyCarriers energyCarrier : v_activeConsumptionEnergyCarriers) {
+for (OL_EnergyCarriers energyCarrier : data.getRapidRunData().activeConsumptionEnergyCarriers) {
 	fm_daytimeImports_MWh.put( energyCarrier, data.getRapidRunData().getDaytimeImport_MWh(energyCarrier) );
 	fm_nighttimeImports_MWh.put( energyCarrier, data.getRapidRunData().getNighttimeImport_MWh(energyCarrier) );
 }
-for (OL_EnergyCarriers energyCarrier : v_activeProductionEnergyCarriers) {
+for (OL_EnergyCarriers energyCarrier : data.getRapidRunData().activeProductionEnergyCarriers) {
 	fm_daytimeExports_MWh.put( energyCarrier, data.getRapidRunData().getDaytimeExport_MWh(energyCarrier) );
 	fm_nighttimeExports_MWh.put( energyCarrier, data.getRapidRunData().getNighttimeExport_MWh(energyCarrier) );
 }
@@ -224,11 +226,11 @@ fm_weekendImports_MWh.clear();
 fm_weekdayExports_MWh.clear();
 fm_weekendExports_MWh.clear();
 
-for (OL_EnergyCarriers energyCarrier : v_activeConsumptionEnergyCarriers) {
+for (OL_EnergyCarriers energyCarrier : data.getRapidRunData().activeConsumptionEnergyCarriers) {
 	fm_weekdayImports_MWh.put( energyCarrier, data.getRapidRunData().getWeekdayImport_MWh(energyCarrier) );
 	fm_weekendImports_MWh.put( energyCarrier, data.getRapidRunData().getWeekendImport_MWh(energyCarrier) );
 }
-for (OL_EnergyCarriers energyCarrier : v_activeProductionEnergyCarriers) {
+for (OL_EnergyCarriers energyCarrier : data.getRapidRunData().activeProductionEnergyCarriers) {
 	fm_weekdayExports_MWh.put( energyCarrier, data.getRapidRunData().getWeekdayExport_MWh(energyCarrier) );
 	fm_weekendExports_MWh.put( energyCarrier, data.getRapidRunData().getWeekendExport_MWh(energyCarrier) );
 }

--- a/_alp/Agents/EnergyDataViewer/Code/Functions.xml
+++ b/_alp/Agents/EnergyDataViewer/Code/Functions.xml
@@ -23,7 +23,7 @@
 		<Name><![CDATA[f_updatePreviousTotalsGC]]></Name>
 		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>1246</X>
-		<Y>-90</Y>
+		<Y>-70</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -59,7 +59,7 @@
 		<Id>1741792546535</Id>
 		<Name><![CDATA[f_updateVariables]]></Name>
 		<X>1246</X>
-		<Y>-230</Y>
+		<Y>-220</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -79,7 +79,7 @@
 		<Id>1741792546537</Id>
 		<Name><![CDATA[f_updateLiveDatasets]]></Name>
 		<X>1246</X>
-		<Y>-210</Y>
+		<Y>-200</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -99,7 +99,7 @@
 		<Id>1741792546539</Id>
 		<Name><![CDATA[f_updateWeeklyDatasets]]></Name>
 		<X>1246</X>
-		<Y>-190</Y>
+		<Y>-180</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -119,7 +119,7 @@
 		<Id>1741792546541</Id>
 		<Name><![CDATA[f_updateYearlyDatasets]]></Name>
 		<X>1246</X>
-		<Y>-170</Y>
+		<Y>-160</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -140,7 +140,7 @@
 		<Name><![CDATA[f_addTimeStepLiveDataSetsGC]]></Name>
 		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>1246</X>
-		<Y>-110</Y>
+		<Y>-90</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -160,7 +160,7 @@
 		<Id>1741792546545</Id>
 		<Name><![CDATA[f_updateLoadDurationCurve]]></Name>
 		<X>1246</X>
-		<Y>-150</Y>
+		<Y>-140</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -181,7 +181,7 @@
 		<Name><![CDATA[f_updateLiveActiveAssetBooleans]]></Name>
 		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>1246</X>
-		<Y>-130</Y>
+		<Y>-110</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>

--- a/_alp/Agents/EnergyDataViewer/Levels/Level.level.xml
+++ b/_alp/Agents/EnergyDataViewer/Levels/Level.level.xml
@@ -54,7 +54,7 @@
 		<Id>1741792546451</Id>
 		<Name><![CDATA[txt_liveWeek]]></Name>
 		<X>151</X>
-		<Y>40</Y>
+		<Y>60</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>
@@ -79,7 +79,7 @@
 		<Id>1741792546453</Id>
 		<Name><![CDATA[txt_year]]></Name>
 		<X>151</X>
-		<Y>650</Y>
+		<Y>460</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>
@@ -103,8 +103,8 @@
 	<Text>
 		<Id>1741792546455</Id>
 		<Name><![CDATA[txt_summerWeek]]></Name>
-		<X>146</X>
-		<Y>1200</Y>
+		<X>150</X>
+		<Y>780</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>
@@ -129,8 +129,8 @@
 	<Text>
 		<Id>1741792546457</Id>
 		<Name><![CDATA[txt_winterWeek]]></Name>
-		<X>146</X>
-		<Y>1850</Y>
+		<X>150</X>
+		<Y>1010</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>
@@ -279,331 +279,6 @@
 		<Alignment>LEFT</Alignment>
 	</Text>
 	<Text>
-		<Id>1741792546469</Id>
-		<Name><![CDATA[txt_liveWeekProduction]]></Name>
-		<X>161</X>
-		<Y>315</Y>
-		<Label>
-			<X>0</X>
-			<Y>-10</Y>
-		</Label>
-		<PublicFlag>true</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>false</ShowLabel>
-		<DrawMode>SHAPE_DRAW_2D</DrawMode>
-		<EmbeddedIcon>false</EmbeddedIcon>
-		<Z>0</Z>
-		<Rotation>0.0</Rotation>
-		<Color>-16777216</Color>
-		<Text><![CDATA[Production]]></Text>
-		<Font>
-			<Name><![CDATA[SansSerif]]></Name>
-			<Size>16</Size>
-			<Style>0</Style>
-		</Font>
-		<Alignment>LEFT</Alignment>
-	</Text>
-	<Text>
-		<Id>1741792546471</Id>
-		<Name><![CDATA[txt_liveWeekProductionElectricity]]></Name>
-		<X>181</X>
-		<Y>335</Y>
-		<Label>
-			<X>0</X>
-			<Y>-10</Y>
-		</Label>
-		<PublicFlag>true</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>false</ShowLabel>
-		<DrawMode>SHAPE_DRAW_2D</DrawMode>
-		<EmbeddedIcon>false</EmbeddedIcon>
-		<Z>0</Z>
-		<Rotation>0.0</Rotation>
-		<Color>-16777216</Color>
-		<Text><![CDATA[Electricity]]></Text>
-		<Font>
-			<Name><![CDATA[SansSerif]]></Name>
-			<Size>16</Size>
-			<Style>2</Style>
-		</Font>
-		<Alignment>LEFT</Alignment>
-	</Text>
-	<Text>
-		<Id>1741792546473</Id>
-		<Name><![CDATA[txt_liveWeekProductionOther]]></Name>
-		<X>186</X>
-		<Y>465</Y>
-		<Label>
-			<X>0</X>
-			<Y>-10</Y>
-		</Label>
-		<PublicFlag>true</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>false</ShowLabel>
-		<DrawMode>SHAPE_DRAW_2D</DrawMode>
-		<EmbeddedIcon>false</EmbeddedIcon>
-		<Z>0</Z>
-		<Rotation>0.0</Rotation>
-		<Color>-16777216</Color>
-		<Text><![CDATA[Other]]></Text>
-		<Font>
-			<Name><![CDATA[SansSerif]]></Name>
-			<Size>16</Size>
-			<Style>2</Style>
-		</Font>
-		<Alignment>LEFT</Alignment>
-	</Text>
-	<Text>
-		<Id>1741792546475</Id>
-		<Name><![CDATA[txt_liveWeekConsumption]]></Name>
-		<X>156</X>
-		<Y>60</Y>
-		<Label>
-			<X>0</X>
-			<Y>-10</Y>
-		</Label>
-		<PublicFlag>true</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>false</ShowLabel>
-		<DrawMode>SHAPE_DRAW_2D</DrawMode>
-		<EmbeddedIcon>false</EmbeddedIcon>
-		<Z>0</Z>
-		<Rotation>0.0</Rotation>
-		<Color>-16777216</Color>
-		<Text><![CDATA[Consumption]]></Text>
-		<Font>
-			<Name><![CDATA[SansSerif]]></Name>
-			<Size>16</Size>
-			<Style>0</Style>
-		</Font>
-		<Alignment>LEFT</Alignment>
-	</Text>
-	<Text>
-		<Id>1741792546477</Id>
-		<Name><![CDATA[txt_liveWeekProductionElectricity1]]></Name>
-		<X>176</X>
-		<Y>80</Y>
-		<Label>
-			<X>0</X>
-			<Y>-10</Y>
-		</Label>
-		<PublicFlag>true</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>false</ShowLabel>
-		<DrawMode>SHAPE_DRAW_2D</DrawMode>
-		<EmbeddedIcon>false</EmbeddedIcon>
-		<Z>0</Z>
-		<Rotation>0.0</Rotation>
-		<Color>-16777216</Color>
-		<Text><![CDATA[Electricity]]></Text>
-		<Font>
-			<Name><![CDATA[SansSerif]]></Name>
-			<Size>16</Size>
-			<Style>2</Style>
-		</Font>
-		<Alignment>LEFT</Alignment>
-	</Text>
-	<Text>
-		<Id>1741792546479</Id>
-		<Name><![CDATA[txt_liveWeekProductionOther1]]></Name>
-		<X>186</X>
-		<Y>240</Y>
-		<Label>
-			<X>0</X>
-			<Y>-10</Y>
-		</Label>
-		<PublicFlag>true</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>false</ShowLabel>
-		<DrawMode>SHAPE_DRAW_2D</DrawMode>
-		<EmbeddedIcon>false</EmbeddedIcon>
-		<Z>0</Z>
-		<Rotation>0.0</Rotation>
-		<Color>-16777216</Color>
-		<Text><![CDATA[Other]]></Text>
-		<Font>
-			<Name><![CDATA[SansSerif]]></Name>
-			<Size>16</Size>
-			<Style>2</Style>
-		</Font>
-		<Alignment>LEFT</Alignment>
-	</Text>
-	<Text>
-		<Id>1741792546481</Id>
-		<Name><![CDATA[txt_yearProduction]]></Name>
-		<X>166</X>
-		<Y>935</Y>
-		<Label>
-			<X>0</X>
-			<Y>-10</Y>
-		</Label>
-		<PublicFlag>true</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>false</ShowLabel>
-		<DrawMode>SHAPE_DRAW_2D</DrawMode>
-		<EmbeddedIcon>false</EmbeddedIcon>
-		<Z>0</Z>
-		<Rotation>0.0</Rotation>
-		<Color>-16777216</Color>
-		<Text><![CDATA[Production]]></Text>
-		<Font>
-			<Name><![CDATA[SansSerif]]></Name>
-			<Size>16</Size>
-			<Style>0</Style>
-		</Font>
-		<Alignment>LEFT</Alignment>
-	</Text>
-	<Text>
-		<Id>1741792546485</Id>
-		<Name><![CDATA[txt_yearConsumption]]></Name>
-		<X>166</X>
-		<Y>670</Y>
-		<Label>
-			<X>0</X>
-			<Y>-10</Y>
-		</Label>
-		<PublicFlag>true</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>false</ShowLabel>
-		<DrawMode>SHAPE_DRAW_2D</DrawMode>
-		<EmbeddedIcon>false</EmbeddedIcon>
-		<Z>0</Z>
-		<Rotation>0.0</Rotation>
-		<Color>-16777216</Color>
-		<Text><![CDATA[Consumption]]></Text>
-		<Font>
-			<Name><![CDATA[SansSerif]]></Name>
-			<Size>16</Size>
-			<Style>0</Style>
-		</Font>
-		<Alignment>LEFT</Alignment>
-	</Text>
-	<Text>
-		<Id>1741792546493</Id>
-		<Name><![CDATA[txt_liveWeekNet]]></Name>
-		<X>166</X>
-		<Y>535</Y>
-		<Label>
-			<X>0</X>
-			<Y>-10</Y>
-		</Label>
-		<PublicFlag>true</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>false</ShowLabel>
-		<DrawMode>SHAPE_DRAW_2D</DrawMode>
-		<EmbeddedIcon>false</EmbeddedIcon>
-		<Z>0</Z>
-		<Rotation>0.0</Rotation>
-		<Color>-16777216</Color>
-		<Text><![CDATA[Net Load Electricity]]></Text>
-		<Font>
-			<Name><![CDATA[SansSerif]]></Name>
-			<Size>16</Size>
-			<Style>0</Style>
-		</Font>
-		<Alignment>LEFT</Alignment>
-	</Text>
-	<Text>
-		<Id>1741792546507</Id>
-		<Name><![CDATA[txt_summerWeekNet]]></Name>
-		<X>176</X>
-		<Y>1720</Y>
-		<Label>
-			<X>0</X>
-			<Y>-10</Y>
-		</Label>
-		<PublicFlag>true</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>false</ShowLabel>
-		<DrawMode>SHAPE_DRAW_2D</DrawMode>
-		<EmbeddedIcon>false</EmbeddedIcon>
-		<Z>0</Z>
-		<Rotation>0.0</Rotation>
-		<Color>-16777216</Color>
-		<Text><![CDATA[Net Load Electricity]]></Text>
-		<Font>
-			<Name><![CDATA[SansSerif]]></Name>
-			<Size>16</Size>
-			<Style>0</Style>
-		</Font>
-		<Alignment>LEFT</Alignment>
-	</Text>
-	<Text>
-		<Id>1741792546509</Id>
-		<Name><![CDATA[txt_winterWeekConsumption]]></Name>
-		<X>166</X>
-		<Y>1870</Y>
-		<Label>
-			<X>0</X>
-			<Y>-10</Y>
-		</Label>
-		<PublicFlag>true</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>false</ShowLabel>
-		<DrawMode>SHAPE_DRAW_2D</DrawMode>
-		<EmbeddedIcon>false</EmbeddedIcon>
-		<Z>0</Z>
-		<Rotation>0.0</Rotation>
-		<Color>-16777216</Color>
-		<Text><![CDATA[Consumption]]></Text>
-		<Font>
-			<Name><![CDATA[SansSerif]]></Name>
-			<Size>16</Size>
-			<Style>0</Style>
-		</Font>
-		<Alignment>LEFT</Alignment>
-	</Text>
-	<Text>
-		<Id>1741792546515</Id>
-		<Name><![CDATA[txt_winterWeekProduction]]></Name>
-		<X>166</X>
-		<Y>2130</Y>
-		<Label>
-			<X>0</X>
-			<Y>-10</Y>
-		</Label>
-		<PublicFlag>true</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>false</ShowLabel>
-		<DrawMode>SHAPE_DRAW_2D</DrawMode>
-		<EmbeddedIcon>false</EmbeddedIcon>
-		<Z>0</Z>
-		<Rotation>0.0</Rotation>
-		<Color>-16777216</Color>
-		<Text><![CDATA[Production]]></Text>
-		<Font>
-			<Name><![CDATA[SansSerif]]></Name>
-			<Size>16</Size>
-			<Style>0</Style>
-		</Font>
-		<Alignment>LEFT</Alignment>
-	</Text>
-	<Text>
-		<Id>1741792546521</Id>
-		<Name><![CDATA[txt_summerWeekNet1]]></Name>
-		<X>176</X>
-		<Y>2370</Y>
-		<Label>
-			<X>0</X>
-			<Y>-10</Y>
-		</Label>
-		<PublicFlag>true</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>false</ShowLabel>
-		<DrawMode>SHAPE_DRAW_2D</DrawMode>
-		<EmbeddedIcon>false</EmbeddedIcon>
-		<Z>0</Z>
-		<Rotation>0.0</Rotation>
-		<Color>-16777216</Color>
-		<Text><![CDATA[Net Load Electricity]]></Text>
-		<Font>
-			<Name><![CDATA[SansSerif]]></Name>
-			<Size>16</Size>
-			<Style>0</Style>
-		</Font>
-		<Alignment>LEFT</Alignment>
-	</Text>
-	<Text>
 		<Id>1741792546523</Id>
 		<Name><![CDATA[txt_DayNightTotals]]></Name>
 		<X>626</X>
@@ -655,9 +330,9 @@
 	</Text>
 	<Text>
 		<Id>1741792546527</Id>
-		<Name><![CDATA[t_activeAssetBooleans]]></Name>
-		<X>1716</X>
-		<Y>510</Y>
+		<Name><![CDATA[t_liveData]]></Name>
+		<X>1280</X>
+		<Y>620</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>
@@ -670,7 +345,7 @@
 		<Z>0</Z>
 		<Rotation>0.0</Rotation>
 		<Color>-16777216</Color>
-		<Text><![CDATA[Active Asset booleans]]></Text>
+		<Text><![CDATA[Live Data]]></Text>
 		<Font>
 			<Name><![CDATA[SansSerif]]></Name>
 			<Size>20</Size>
@@ -713,4 +388,29 @@
 			<LabelText>Back to Agent</LabelText>
 		</ExtendedProperties>
 	</Control>
+	<Text>
+		<Id>1758803480802</Id>
+		<Name><![CDATA[t_rapidRunData]]></Name>
+		<X>1580</X>
+		<Y>620</Y>
+		<Label>
+			<X>0</X>
+			<Y>-10</Y>
+		</Label>
+		<PublicFlag>true</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>false</ShowLabel>
+		<DrawMode>SHAPE_DRAW_2D</DrawMode>
+		<EmbeddedIcon>false</EmbeddedIcon>
+		<Z>0</Z>
+		<Rotation>0.0</Rotation>
+		<Color>-16777216</Color>
+		<Text><![CDATA[RapidRun Data]]></Text>
+		<Font>
+			<Name><![CDATA[SansSerif]]></Name>
+			<Size>20</Size>
+			<Style>0</Style>
+		</Font>
+		<Alignment>LEFT</Alignment>
+	</Text>
 </Presentation>

--- a/_alp/Agents/EnergyDataViewer/Variables.xml
+++ b/_alp/Agents/EnergyDataViewer/Variables.xml
@@ -58,26 +58,6 @@
 		</Properties>
 	</Variable>
 	<Variable Class="PlainVariable">
-		<Id>1741792546553</Id>
-		<Name><![CDATA[v_totalTimeOverloaded_h]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>1206</X>
-		<Y>280</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[double]]></Type>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
 		<Id>1741792546555</Id>
 		<Name><![CDATA[v_gridCapacityFeedIn_kW]]></Name>
 		<X>1216</X>
@@ -198,8 +178,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546567</Id>
 		<Name><![CDATA[v_dataDistrictHeatConsumptionLiveWeek_kW]]></Name>
-		<X>206</X>
-		<Y>290</Y>
+		<X>180</X>
+		<Y>210</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -280,26 +260,6 @@
 		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>-330</X>
 		<Y>320</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[DataSet]]></Type>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
-		<Id>1741792546577</Id>
-		<Name><![CDATA[v_dataDistrictHeatProductionLiveWeek_kW]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>206</X>
-		<Y>515</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -411,26 +371,6 @@
 		</Properties>
 	</Variable>
 	<Variable Class="PlainVariable">
-		<Id>1741792546589</Id>
-		<Name><![CDATA[v_dataNetLoadYear_kW]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>1206</X>
-		<Y>250</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[double[]]]></Type>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
 		<Id>1741792546591</Id>
 		<Name><![CDATA[v_totalElectricitySelfConsumed_MWh]]></Name>
 		<X>686</X>
@@ -509,8 +449,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546599</Id>
 		<Name><![CDATA[data_dailyAverageFinalEnergyConsumption_kW]]></Name>
-		<X>206</X>
-		<Y>920</Y>
+		<X>180</X>
+		<Y>630</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -671,45 +611,6 @@
 		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>-400</X>
 		<Y>930</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[DataSet]]></Type>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
-		<Id>1741792546617</Id>
-		<Name><![CDATA[v_dataDistrictHeatProductionYear_kW]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>206</X>
-		<Y>1125</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[DataSet]]></Type>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
-		<Id>1741792546619</Id>
-		<Name><![CDATA[v_dataDistrictHeatConsumptionYear_kW]]></Name>
-		<X>206</X>
-		<Y>900</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -944,25 +845,6 @@
 		</Properties>
 	</Variable>
 	<Variable Class="PlainVariable">
-		<Id>1741792546645</Id>
-		<Name><![CDATA[v_dataDistrictHeatConsumptionWinterWeek_kW]]></Name>
-		<X>206</X>
-		<Y>2100</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[DataSet]]></Type>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
 		<Id>1741792546647</Id>
 		<Name><![CDATA[v_dataElectricityForHydrogenConsumptionWinterWeek_kW]]></Name>
 		<ExcludeFromBuild>true</ExcludeFromBuild>
@@ -1063,26 +945,6 @@
 		</Properties>
 	</Variable>
 	<Variable Class="PlainVariable">
-		<Id>1741792546657</Id>
-		<Name><![CDATA[v_dataDistrictHeatProductionSummerWeek_kW]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>206</X>
-		<Y>1690</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[DataSet]]></Type>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
 		<Id>1741792546659</Id>
 		<Name><![CDATA[v_dataElectricityWindProductionWinterWeek_kW]]></Name>
 		<ExcludeFromBuild>true</ExcludeFromBuild>
@@ -1148,26 +1010,6 @@
 		<ExcludeFromBuild>true</ExcludeFromBuild>
 		<X>-360</X>
 		<Y>2150</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[DataSet]]></Type>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
-		<Id>1741792546667</Id>
-		<Name><![CDATA[v_dataDistrictHeatProductionWinterWeek_kW]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>206</X>
-		<Y>2340</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1356,8 +1198,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546687</Id>
 		<Name><![CDATA[v_dataElectricityFeedInCapacityLiveWeek_kW]]></Name>
-		<X>206</X>
-		<Y>605</Y>
+		<X>180</X>
+		<Y>310</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1375,8 +1217,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546689</Id>
 		<Name><![CDATA[v_dataElectricityDeliveryCapacityLiveWeek_kW]]></Name>
-		<X>206</X>
-		<Y>585</Y>
+		<X>180</X>
+		<Y>290</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1394,8 +1236,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546719</Id>
 		<Name><![CDATA[v_dataNetLoadLiveWeek_kW]]></Name>
-		<X>206</X>
-		<Y>565</Y>
+		<X>180</X>
+		<Y>260</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1413,8 +1255,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546721</Id>
 		<Name><![CDATA[v_dataNetLoadSummerWeek_kW]]></Name>
-		<X>206</X>
-		<Y>1750</Y>
+		<X>180</X>
+		<Y>920</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1432,8 +1274,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546723</Id>
 		<Name><![CDATA[v_dataNetLoadWinterWeek_kW]]></Name>
-		<X>206</X>
-		<Y>2400</Y>
+		<X>184</X>
+		<Y>1170</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2764,8 +2606,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546857</Id>
 		<Name><![CDATA[dsm_dailyAverageConsumptionDataSets_kW]]></Name>
-		<X>206</X>
-		<Y>880</Y>
+		<X>180</X>
+		<Y>560</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2786,8 +2628,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546859</Id>
 		<Name><![CDATA[dsm_dailyAverageProductionDataSets_kW]]></Name>
-		<X>206</X>
-		<Y>1105</Y>
+		<X>180</X>
+		<Y>580</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2808,8 +2650,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546861</Id>
 		<Name><![CDATA[dsm_summerWeekConsumptionDataSets_kW]]></Name>
-		<X>206</X>
-		<Y>1430</Y>
+		<X>180</X>
+		<Y>860</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2830,8 +2672,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546863</Id>
 		<Name><![CDATA[dsm_summerWeekProductionDataSets_kW]]></Name>
-		<X>206</X>
-		<Y>1453</Y>
+		<X>180</X>
+		<Y>883</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2852,8 +2694,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546865</Id>
 		<Name><![CDATA[dsm_winterWeekConsumptionDataSets_kW]]></Name>
-		<X>206</X>
-		<Y>2080</Y>
+		<X>184</X>
+		<Y>1100</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2874,8 +2716,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546867</Id>
 		<Name><![CDATA[dsm_winterWeekProductionDataSets_kW]]></Name>
-		<X>206</X>
-		<Y>2320</Y>
+		<X>184</X>
+		<Y>1120</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2896,8 +2738,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546869</Id>
 		<Name><![CDATA[dsm_liveConsumption_kW]]></Name>
-		<X>206</X>
-		<Y>270</Y>
+		<X>180</X>
+		<Y>150</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -2918,8 +2760,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546871</Id>
 		<Name><![CDATA[dsm_liveProduction_kW]]></Name>
-		<X>206</X>
-		<Y>495</Y>
+		<X>180</X>
+		<Y>170</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -3076,9 +2918,9 @@
 	</Variable>
 	<Variable Class="PlainVariable">
 		<Id>1741792546887</Id>
-		<Name><![CDATA[v_activeProductionEnergyCarriers]]></Name>
-		<X>606</X>
-		<Y>-30</Y>
+		<Name><![CDATA[v_liveProductionEnergyCarriers]]></Name>
+		<X>1270</X>
+		<Y>700</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -3091,16 +2933,13 @@
               AccessType="public"
               StaticVariable="false">
 			<Type><![CDATA[EnumSet<OL_EnergyCarriers>]]></Type>
-			<InitialValue Class="CodeValue">
-				<Code><![CDATA[EnumSet.of(OL_EnergyCarriers.ELECTRICITY);]]></Code>
-			</InitialValue>
 		</Properties>
 	</Variable>
 	<Variable Class="PlainVariable">
 		<Id>1741792546889</Id>
-		<Name><![CDATA[v_activeConsumptionEnergyCarriers]]></Name>
-		<X>606</X>
-		<Y>-10</Y>
+		<Name><![CDATA[v_liveConsumptionEnergyCarriers]]></Name>
+		<X>1270</X>
+		<Y>720</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -3113,9 +2952,6 @@
               AccessType="public"
               StaticVariable="false">
 			<Type><![CDATA[EnumSet<OL_EnergyCarriers>]]></Type>
-			<InitialValue Class="CodeValue">
-				<Code><![CDATA[EnumSet.of(OL_EnergyCarriers.ELECTRICITY);]]></Code>
-			</InitialValue>
 		</Properties>
 	</Variable>
 	<Variable Class="PlainVariable">
@@ -3145,29 +2981,6 @@
 		<Name><![CDATA[b_isRealFeedinCapacityAvailable]]></Name>
 		<X>1216</X>
 		<Y>380</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[boolean]]></Type>
-			<InitialValue Class="CodeValue">
-				<Code><![CDATA[false]]></Code>
-			</InitialValue>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
-		<Id>1741792546895</Id>
-		<Name><![CDATA[b_hasHeatGridConnection]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>1726</X>
-		<Y>650</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -3266,213 +3079,6 @@
 		</Properties>
 	</Variable>
 	<Variable Class="PlainVariable">
-		<Id>1741792546905</Id>
-		<Name><![CDATA[b_hasElectrolyser]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>1726</X>
-		<Y>670</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[boolean]]></Type>
-			<InitialValue Class="CodeValue">
-				<Code><![CDATA[false]]></Code>
-			</InitialValue>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
-		<Id>1741792546907</Id>
-		<Name><![CDATA[b_hasCHP]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>1726</X>
-		<Y>690</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[boolean]]></Type>
-			<InitialValue Class="CodeValue">
-				<Code><![CDATA[false]]></Code>
-			</InitialValue>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
-		<Id>1741792546909</Id>
-		<Name><![CDATA[b_hasPV]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>1726</X>
-		<Y>590</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[boolean]]></Type>
-			<InitialValue Class="CodeValue">
-				<Code><![CDATA[true]]></Code>
-			</InitialValue>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
-		<Id>1741792546911</Id>
-		<Name><![CDATA[b_hasWindturbine]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>1726</X>
-		<Y>610</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[boolean]]></Type>
-			<InitialValue Class="CodeValue">
-				<Code><![CDATA[true]]></Code>
-			</InitialValue>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
-		<Id>1741792546913</Id>
-		<Name><![CDATA[b_hasV2G]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>1726</X>
-		<Y>710</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[boolean]]></Type>
-			<InitialValue Class="CodeValue">
-				<Code><![CDATA[false]]></Code>
-			</InitialValue>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
-		<Id>1741792546915</Id>
-		<Name><![CDATA[b_hasBattery]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>1726</X>
-		<Y>630</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[boolean]]></Type>
-			<InitialValue Class="CodeValue">
-				<Code><![CDATA[true]]></Code>
-			</InitialValue>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
-		<Id>1741792546917</Id>
-		<Name><![CDATA[b_hasElectricHeating]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>1726</X>
-		<Y>550</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[boolean]]></Type>
-			<InitialValue Class="CodeValue">
-				<Code><![CDATA[true]]></Code>
-			</InitialValue>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
-		<Id>1741792546919</Id>
-		<Name><![CDATA[b_hasElectricTransport]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>1726</X>
-		<Y>570</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[boolean]]></Type>
-			<InitialValue Class="CodeValue">
-				<Code><![CDATA[true]]></Code>
-			</InitialValue>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
-		<Id>1741792546921</Id>
-		<Name><![CDATA[b_hasElectricCooking]]></Name>
-		<ExcludeFromBuild>true</ExcludeFromBuild>
-		<X>1726</X>
-		<Y>730</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[boolean]]></Type>
-			<InitialValue Class="CodeValue">
-				<Code><![CDATA[false]]></Code>
-			</InitialValue>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
 		<Id>1741792546923</Id>
 		<Name><![CDATA[v_totalWindEnergyCurtailed_MWh]]></Name>
 		<X>1726</X>
@@ -3551,8 +3157,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546931</Id>
 		<Name><![CDATA[v_dataBatterySOCLiveWeek_fr]]></Name>
-		<X>196</X>
-		<Y>635</Y>
+		<X>180</X>
+		<Y>360</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -3573,8 +3179,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546933</Id>
 		<Name><![CDATA[v_dataBatterySOCYear_fr]]></Name>
-		<X>186</X>
-		<Y>1170</Y>
+		<X>180</X>
+		<Y>670</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -3595,8 +3201,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546935</Id>
 		<Name><![CDATA[v_dataBatterySOCSummerWeek_fr]]></Name>
-		<X>206</X>
-		<Y>1790</Y>
+		<X>180</X>
+		<Y>960</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -3617,8 +3223,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1741792546937</Id>
 		<Name><![CDATA[v_dataBatterySOCWinterWeek_fr]]></Name>
-		<X>206</X>
-		<Y>2440</Y>
+		<X>184</X>
+		<Y>1210</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -3653,25 +3259,6 @@
               AccessType="public"
               StaticVariable="false">
 			<Type><![CDATA[double]]></Type>
-		</Properties>
-	</Variable>
-	<Variable Class="PlainVariable">
-		<Id>1741792546941</Id>
-		<Name><![CDATA[v_numberOfGridconnections]]></Name>
-		<X>1106</X>
-		<Y>-10</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true"
-              Constant="false"
-              AccessType="public"
-              StaticVariable="false">
-			<Type><![CDATA[int]]></Type>
 		</Properties>
 	</Variable>
 	<Variable Class="PlainVariable">
@@ -3804,7 +3391,7 @@
               Constant="false"
               AccessType="public"
               StaticVariable="false">
-			<Type><![CDATA[Agent]]></Type>
+			<Type><![CDATA[I_EnergyData]]></Type>
 		</Properties>
 	</Variable>
 	<Variable Class="PlainVariable">
@@ -3962,8 +3549,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1754307361345</Id>
 		<Name><![CDATA[dsm_assetFlowsSummerWeek_kW]]></Name>
-		<X>206</X>
-		<Y>1403</Y>
+		<X>180</X>
+		<Y>833</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -3984,8 +3571,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1754307559209</Id>
 		<Name><![CDATA[dsm_assetFlowsWinterWeek_kW]]></Name>
-		<X>206</X>
-		<Y>2059</Y>
+		<X>184</X>
+		<Y>1069</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -4006,8 +3593,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1754307918052</Id>
 		<Name><![CDATA[dsm_assetFlowsAccumulators_kW]]></Name>
-		<X>207</X>
-		<Y>790</Y>
+		<X>180</X>
+		<Y>520</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -4028,8 +3615,8 @@
 	<Variable Class="PlainVariable">
 		<Id>1754308111992</Id>
 		<Name><![CDATA[dsm_liveAssetFlowsAccumulators_kW]]></Name>
-		<X>200</X>
-		<Y>220</Y>
+		<X>180</X>
+		<Y>110</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -4049,9 +3636,66 @@
 	</Variable>
 	<Variable Class="PlainVariable">
 		<Id>1754312472355</Id>
-		<Name><![CDATA[v_activeAssetFlows]]></Name>
-		<X>1726</X>
-		<Y>750</Y>
+		<Name><![CDATA[v_liveAssetFlowCategories]]></Name>
+		<X>1270</X>
+		<Y>670</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Properties SaveInSnapshot="true"
+              Constant="false"
+              AccessType="public"
+              StaticVariable="false">
+			<Type><![CDATA[EnumSet<OL_AssetFlowCategories>]]></Type>
+		</Properties>
+	</Variable>
+	<Variable Class="PlainVariable">
+		<Id>1758803622755</Id>
+		<Name><![CDATA[v_rapidRunProductionEnergyCarriers]]></Name>
+		<X>1590</X>
+		<Y>700</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Properties SaveInSnapshot="true"
+              Constant="false"
+              AccessType="public"
+              StaticVariable="false">
+			<Type><![CDATA[EnumSet<OL_EnergyCarriers>]]></Type>
+		</Properties>
+	</Variable>
+	<Variable Class="PlainVariable">
+		<Id>1758803622757</Id>
+		<Name><![CDATA[v_rapidRunConsumptionEnergyCarriers]]></Name>
+		<X>1590</X>
+		<Y>720</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Properties SaveInSnapshot="true"
+              Constant="false"
+              AccessType="public"
+              StaticVariable="false">
+			<Type><![CDATA[EnumSet<OL_EnergyCarriers>]]></Type>
+		</Properties>
+	</Variable>
+	<Variable Class="PlainVariable">
+		<Id>1758803622759</Id>
+		<Name><![CDATA[v_rapidRunAssetFlowCategories]]></Name>
+		<X>1590</X>
+		<Y>670</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>


### PR DESCRIPTION
Cleanup of canvas and addition of contrast between enumsets of assetflowscategories/energycarriers of livedata vs rapidrundata