### PR TITLE
Bugfix sl_publicChargersResidentialArea_pct: adjustment to f_setActive

### DIFF
--- a/_alp/Agents/GridConnection/Code/Functions.java
+++ b/_alp/Agents/GridConnection/Code/Functions.java
@@ -628,15 +628,11 @@ else {
 	
 	//Fast forward time dependent energy assets (if present)
 	c_chargingSessions.forEach(cs -> cs.fastForwardCharingSessions(timeVariables.getT_h(), p_chargePoint));
+	c_vehicleAssets.forEach(vehicle -> vehicle.setAvailability(true));
 	if (p_chargePoint != null) {
 	    c_tripTrackers.forEach(tt -> {
-	        if (tt.vehicle instanceof J_EAEV ev) {
-	            if (!ev.getAvailability()) {
-	                return; // EV is on a trip: do not touch chargePoint registration or tripTracker state
-	            }
-	            if (p_chargePoint.isRegistered(ev)) {
-	                p_chargePoint.deregisterChargingRequest(ev);
-	            }
+	        if (tt.vehicle instanceof J_EAEV ev && p_chargePoint.isRegistered(ev)) {
+	            p_chargePoint.deregisterChargingRequest(ev);
 	        }
 	        tt.setStartIndex(timeVariables, f_getChargePoint());
 	    });

--- a/_alp/Classes/Class.I_Vehicle.java
+++ b/_alp/Classes/Class.I_Vehicle.java
@@ -20,6 +20,7 @@ public interface I_Vehicle
     
     void setVehicleScaling(double vehicleScaling);    
 	void setTripTracker(J_ActivityTrackerTrips tracker);
+	void setAvailability(boolean available);
 	
 	J_ActivityTrackerTrips getTripTracker();
 	boolean getAvailability();

--- a/_alp/Classes/Class.J_EAEV.java
+++ b/_alp/Classes/Class.J_EAEV.java
@@ -175,6 +175,10 @@ public class J_EAEV extends J_EAFlex implements I_Vehicle, I_ChargingRequest {
 		return this.available;
 	}
 	
+	public void setAvailability(boolean available) {
+    	this.available = available;
+    }
+	
 	public double getVehicleScaling_fr() {
 		return this.vehicleScaling;
 	}

--- a/_alp/Classes/Class.J_EAFuelVehicle.java
+++ b/_alp/Classes/Class.J_EAFuelVehicle.java
@@ -79,6 +79,10 @@ public class J_EAFuelVehicle extends J_EAFixed implements I_Vehicle, Serializabl
 	    	return true;
 		}
     }
+    
+    public void setAvailability(boolean available) {
+    	this.available = available;
+    }
 
 	public boolean progressTrip(double marginalTripDist_km) {
 		if( available) {


### PR DESCRIPTION
When sl_publicChargersResidentialArea_pct is set higher, prints traceln "ChargingRequest duration negative" because setStartIndex is not called on c_tripTrackers.
J_ActivityTrackerTrips has a stale nextEventStartTime_h cached from before the GC was deactivated. Since getLeaveTime_h() returns this stale past time, leaveTime_h - t_h < 0, causing error traceln "ChargingRequest duration negative".
So, the chargepoint's registered requests needs to be deregistered first before calling setStartindex. EV availability needs to be checked before deregistering -> Otherwise RuntimeException: "Trying to charge EV that is not available for charging!"