### PR TITLE
Remove getExperiment calls

### DIFF
--- a/_alp/Agents/EnergyModel/Code/Functions.java
+++ b/_alp/Agents/EnergyModel/Code/Functions.java
@@ -554,7 +554,7 @@ startDate.setHours(0);
 startDate.setMinutes(0);
 traceln("Startdate: %s", startDate);
 //startDate.set
-getExperiment().getEngine().setStartDate(startDate); 
+getEngine().setStartDate(startDate); 
 */
 
 //traceln("Day of the week on january 1st %s: %s, int value: %s", p_year, DayOfWeek.from(localDate).name(), v_dayOfWeek1jan);
@@ -1055,7 +1055,7 @@ startDate.setHours(0);
 startDate.setMinutes(0);
 traceln("Startdate: %s", startDate);
 //startDate.set
-getExperiment().getEngine().setStartDate(startDate); 
+getEngine().setStartDate(startDate); 
 */
 
 f_initializeForecasts();
@@ -1163,7 +1163,7 @@ for (EnergyCoop EC : pop_energyCoops) {
 
 Date f_getDate()
 {/*ALCODESTART::1758012535712*/
-Date startDate = getExperiment().getEngine().getStartDate();
+Date startDate = getEngine().getStartDate();
 long startDateUnixTime_ms = startDate.getTime();
 long runtime_ms = (long) (v_timeStepsElapsed * p_timeParameters.getTimeStep_h() * 60 * 60 * 1000);
 Date date = new Date();
@@ -1223,7 +1223,7 @@ startDate.setHours(0);
 startDate.setMinutes(0);
 traceln("Startdate: %s", startDate);
 //startDate.set
-getExperiment().getEngine().setStartDate(startDate); 
+getEngine().setStartDate(startDate); 
 
 
 
@@ -1305,7 +1305,7 @@ startDate.setHours(0);
 startDate.setMinutes(0);
 traceln("Startdate: %s", startDate);
 //startDate.set
-getExperiment().getEngine().setStartDate(startDate); 
+getEngine().setStartDate(startDate); 
 
 
 /*ALCODEEND*/}


### PR DESCRIPTION
getExperiment() is called just to get the AnyLogic Engine even though every agent already has a reference to the Engine.

With this change it's easier to use Lux without instantiating an experiment.