### PR TITLE
Adding DIESEL_GEN to OL_GISObjectType

### DIFF
--- a/Zero_engine.alpx
+++ b/Zero_engine.alpx
@@ -181,6 +181,10 @@
 					<Id>1749729312023</Id>
 					<Name><![CDATA[PARKING]]></Name>
 				</Option>
+				<Option>
+					<Id>1779785585114</Id>
+					<Name><![CDATA[DIESEL_GEN]]></Name>
+				</Option>
 			</OptionList>
 			<OptionList>
 				<Id>1659118426374</Id>


### PR DESCRIPTION
A requirement for https://github.com/Zenmo/zero_Interface-Loader/pull/293