### PR TITLE
EnergyModel: Remove root grid nodes

### DIFF
--- a/_alp/Agents/EnergyModel/Code/Functions.java
+++ b/_alp/Agents/EnergyModel/Code/Functions.java
@@ -77,7 +77,7 @@ for(GridNode n : c_gridNodeExecutionList) {
 	n.f_calculateEnergyBalance(p_timeVariables, p_timeParameters, v_isRapidRun);
 }
 
-for(GridNode n : c_gridNodesTopLevel) {
+for(GridNode n : f_getRootGridNodes()) {
 	if (n.p_energyCarrier == OL_EnergyCarriers.ELECTRICITY) {
 		v_currentElectricityImport_kW += max(0, n.v_currentLoad_kW );
 		v_currentElectricityExport_kW += max(0, -n.v_currentLoad_kW );
@@ -468,8 +468,6 @@ for( GridNode GN : pop_gridNodes ) {
 // First clear lists (needed after deserialisation)
 c_gridNodeExecutionList.clear();
 c_gridNodeExecutionListReverse.clear();
-c_gridNodesTopLevel.clear();
-c_gridNodesNotTopLevel.clear();
 	
 // Then build execution order list
 for( GridNode GN : pop_gridNodes ) {
@@ -477,7 +475,6 @@ for( GridNode GN : pop_gridNodes ) {
 	//if (GN.p_parentNodeID == null) {
 	if (parentNode == null) {
 		f_gridNodeRecursiveAdd(GN);
-		c_gridNodesTopLevel.add(GN);
 		if(GN.p_energyCarrier == OL_EnergyCarriers.ELECTRICITY){
 			topLevelElectricGridCapacity_kW +=GN.p_capacity_kW;
 			if(!GN.p_realCapacityAvailable){
@@ -485,7 +482,6 @@ for( GridNode GN : pop_gridNodes ) {
 			}
 		}
 	} else {
-		c_gridNodesNotTopLevel.add(GN);	
 		if (GN.p_gridNodeID.equals(parentNode.p_parentNodeID)) {
 			traceln("Throwing exception because of circular dependency between gridNodes! GridNode %s and parentNode %s", GN.p_gridNodeID, parentNode.p_gridNodeID);
 			throw new RuntimeException("Exception: circular GridNode dependency, only tree-topology supported");
@@ -624,14 +620,17 @@ ArrayList<J_EA> f_getEnergyAssets()
 return c_energyAssets;
 /*ALCODEEND*/}
 
-ArrayList<GridNode> f_getGridNodesTopLevel()
-{/*ALCODESTART::1718289616227*/
-return this.c_gridNodesTopLevel;
-/*ALCODEEND*/}
-
-ArrayList<GridNode> f_getGridNodesNotTopLevel()
+List<GridNode> f_getNonRootGridNodes()
 {/*ALCODESTART::1718289761647*/
-return this.c_gridNodesNotTopLevel;
+var topGridNodes = new ArrayList<GridNode>();
+
+for (var gridNode: this.pop_gridNodes) {
+    if (gridNode.p_parentNodeID != null) {
+        topGridNodes.add(gridNode);
+    }
+}
+
+return Collections.unmodifiableList(topGridNodes);
 /*ALCODEEND*/}
 
 double f_initializePause()
@@ -1316,5 +1315,18 @@ double f_checkConfiguration()
 {/*ALCODESTART::1772104199229*/
 c_gridConnections.forEach(gc -> gc.f_checkConfiguration());
 
+/*ALCODEEND*/}
+
+List<GridNode> f_getRootGridNodes()
+{/*ALCODESTART::1781165095077*/
+var topGridNodes = new ArrayList<GridNode>();
+
+for (var gridNode: this.pop_gridNodes) {
+    if (gridNode.p_parentNodeID == null) {
+        topGridNodes.add(gridNode);
+    }
+}
+
+return Collections.unmodifiableList(topGridNodes);
 /*ALCODEEND*/}
 

--- a/_alp/Agents/EnergyModel/Code/Functions.xml
+++ b/_alp/Agents/EnergyModel/Code/Functions.xml
@@ -298,25 +298,9 @@
 	</Function>
 	<Function AccessType="public" StaticFunction="false">
 		<ReturnModificator>RETURNS_VALUE</ReturnModificator>
-		<ReturnType>ArrayList&lt;GridNode&gt;</ReturnType>
-		<Id>1718289616227</Id>
-		<Name><![CDATA[f_getGridNodesTopLevel]]></Name>
-		<X>1640</X>
-		<Y>720</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Body xmlns:al="http://anylogic.com"/>
-	</Function>
-	<Function AccessType="public" StaticFunction="false">
-		<ReturnModificator>RETURNS_VALUE</ReturnModificator>
-		<ReturnType>ArrayList&lt;GridNode&gt;</ReturnType>
+		<ReturnType>List&lt;GridNode&gt;</ReturnType>
 		<Id>1718289761647</Id>
-		<Name><![CDATA[f_getGridNodesNotTopLevel]]></Name>
+		<Name><![CDATA[f_getNonRootGridNodes]]></Name>
 		<X>1640</X>
 		<Y>740</Y>
 		<Label>
@@ -774,6 +758,22 @@
 		<Name><![CDATA[f_checkConfiguration]]></Name>
 		<X>1640</X>
 		<Y>170</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
+	<Function AccessType="public" StaticFunction="false">
+		<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+		<ReturnType>List&lt;GridNode&gt;</ReturnType>
+		<Id>1781165095077</Id>
+		<Name><![CDATA[f_getRootGridNodes]]></Name>
+		<X>1640</X>
+		<Y>720</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>

--- a/_alp/Agents/EnergyModel/Variables.xml
+++ b/_alp/Agents/EnergyModel/Variables.xml
@@ -1832,42 +1832,6 @@
 		</Properties>
 	</Variable>
 	<Variable Class="CollectionVariable">
-		<Id>1663251681035</Id>
-		<Name><![CDATA[c_gridNodesTopLevel]]></Name>
-		<X>399</X>
-		<Y>108</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true" AccessType="default" StaticVariable="false">
-			<CollectionClass>ArrayList</CollectionClass>
-			<ElementClass>GridNode</ElementClass>
-			<ValueElementClass>String</ValueElementClass>
-		</Properties>
-	</Variable>
-	<Variable Class="CollectionVariable">
-		<Id>1663252052482</Id>
-		<Name><![CDATA[c_gridNodesNotTopLevel]]></Name>
-		<X>399</X>
-		<Y>128</Y>
-		<Label>
-			<X>10</X>
-			<Y>0</Y>
-		</Label>
-		<PublicFlag>false</PublicFlag>
-		<PresentationFlag>true</PresentationFlag>
-		<ShowLabel>true</ShowLabel>
-		<Properties SaveInSnapshot="true" AccessType="default" StaticVariable="false">
-			<CollectionClass>ArrayList</CollectionClass>
-			<ElementClass>GridNode</ElementClass>
-			<ValueElementClass>String</ValueElementClass>
-		</Properties>
-	</Variable>
-	<Variable Class="CollectionVariable">
 		<Id>1663312177330</Id>
 		<Name><![CDATA[c_gridConnections]]></Name>
 		<X>90</X>

--- a/_alp/Agents/GridConnection/Code/Functions.java
+++ b/_alp/Agents/GridConnection/Code/Functions.java
@@ -185,7 +185,7 @@ if ( c_connectedGISObjects.size()>0) {
 	//If GC has no assigned trafo_id --> Assign to nearest trafo
 	if (p_parentNodeElectricID == null){
 		//Set nearest agent as trafo
-		GridNode nearestLVStation = getNearestAgent(energyModel.c_gridNodesNotTopLevel);
+		GridNode nearestLVStation = getNearestAgent(energyModel.f_getNonRootGridNodes());
 		if (nearestLVStation!=null) {
 			p_parentNodeElectricID = nearestLVStation.p_gridNodeID;
 		}

--- a/_alp/Classes/Class.J_DataSetMap.java
+++ b/_alp/Classes/Class.J_DataSetMap.java
@@ -28,7 +28,16 @@ public class J_DataSetMap <E extends Enum<E>> implements Serializable {
     }
     
     public DataSet get(E key) {
-		return datasetArray[key.ordinal()];
+    	var dataset = datasetArray[key.ordinal()];
+    	if (dataset == null) {
+    		throw new RuntimeException(
+    				String.format(
+    						"This dataset has not been initialized for option %s",
+    						key
+					)
+			);
+    	}
+    	return dataset;
 	}
     	
 


### PR DESCRIPTION
Remove collecions which track root and non-root grid nodes and replace
them by functions which filter on demand.

This makes this functionality less dependent on initialization order and
easier to use correctly.

Also changed the naming from "top level" to "root" as this is less
ambiguous and shorter.

LUX Interface Loader has an accompanying change.