### PR TITLE
heating preferences change

### DIFF
--- a/_alp/Agents/GridConnection/Code/Functions.java
+++ b/_alp/Agents/GridConnection/Code/Functions.java
@@ -548,7 +548,7 @@ else {
 }
 /*ALCODEEND*/}
 
-double f_addHeatManagement(OL_GridConnectionHeatingType heatingType,boolean isGhost)
+double f_addHeatManagement(OL_GridConnectionHeatingType heatingType,boolean isGhost,J_HeatingPreferences heatingPreferences)
 {/*ALCODESTART::1754393382442*/
 if (heatingType == OL_GridConnectionHeatingType.NONE) {
 	return;
@@ -578,9 +578,9 @@ catch (Exception e) {
 	e.printStackTrace();
 }
 
-J_HeatingPreferences existingHeatingPreferences = f_getHeatingManagement() != null ? f_getHeatingManagement().getHeatingPreferences() : null; //Store the existing heating preferences
+//J_HeatingPreferences existingHeatingPreferences = f_getHeatingManagement() != null ? f_getHeatingManagement().getHeatingPreferences() : null; //Store the existing heating preferences
 
-heatingManagement.setHeatingPreferences(existingHeatingPreferences); // Reasign the existing heating preferences
+heatingManagement.setHeatingPreferences(heatingPreferences); // Reasign the existing heating preferences
 f_setExternalAssetManagement(heatingManagement);
 
 /*ALCODEEND*/}
@@ -1221,5 +1221,13 @@ if(this.p_energyManagement != null){
 else{
 	return false;
 }
+/*ALCODEEND*/}
+
+J_HeatingPreferences f_getHeatingPreferences()
+{/*ALCODESTART::1781165937788*/
+if (f_getHeatingManagement() != null) {
+	return f_getHeatingManagement().getHeatingPreferences();
+}
+return null;
 /*ALCODEEND*/}
 

--- a/_alp/Agents/GridConnection/Code/Functions.xml
+++ b/_alp/Agents/GridConnection/Code/Functions.xml
@@ -415,7 +415,7 @@
 		<Id>1753969724598</Id>
 		<Name><![CDATA[f_removeAllHeatingAssets]]></Name>
 		<X>645</X>
-		<Y>360</Y>
+		<Y>380</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -431,7 +431,7 @@
 		<Id>1754051705071</Id>
 		<Name><![CDATA[f_getCurrentHeatingType]]></Name>
 		<X>645</X>
-		<Y>320</Y>
+		<Y>340</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -463,6 +463,10 @@
 		<Parameter>
 			<Name><![CDATA[isGhost]]></Name>
 			<Type><![CDATA[boolean]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[heatingPreferences]]></Name>
+			<Type><![CDATA[J_HeatingPreferences]]></Type>
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
@@ -556,7 +560,7 @@
 		<Id>1754582754934</Id>
 		<Name><![CDATA[f_activateV2GChargingMode]]></Name>
 		<X>675</X>
-		<Y>580</Y>
+		<Y>600</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -585,7 +589,7 @@
 		<Name><![CDATA[f_addChargingManagement]]></Name>
 		<Description><![CDATA[This function takes heatingType as an argument and adds the default heating management class to the GridConnection]]></Description>
 		<X>666</X>
-		<Y>541</Y>
+		<Y>561</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -633,7 +637,7 @@
 		<Id>1762851936576</Id>
 		<Name><![CDATA[f_setChargingManagement]]></Name>
 		<X>666</X>
-		<Y>521</Y>
+		<Y>541</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -653,7 +657,7 @@
 		<Id>1762852865038</Id>
 		<Name><![CDATA[f_getHeatingTypeIsGhost]]></Name>
 		<X>645</X>
-		<Y>340</Y>
+		<Y>360</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -689,7 +693,7 @@
 		<Id>1762853347370</Id>
 		<Name><![CDATA[f_getCurrentChargingType]]></Name>
 		<X>676</X>
-		<Y>561</Y>
+		<Y>581</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -705,7 +709,7 @@
 		<Id>1762853561122</Id>
 		<Name><![CDATA[f_getV2GActive]]></Name>
 		<X>676</X>
-		<Y>601</Y>
+		<Y>621</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -720,8 +724,8 @@
 		<ReturnType>I_BatteryManagement</ReturnType>
 		<Id>1762853894937</Id>
 		<Name><![CDATA[f_getBatteryManagement]]></Name>
-		<X>676</X>
-		<Y>831</Y>
+		<X>666</X>
+		<Y>851</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -756,8 +760,8 @@
 		<ReturnType>double</ReturnType>
 		<Id>1762855733010</Id>
 		<Name><![CDATA[f_setBatteryManagement]]></Name>
-		<X>676</X>
-		<Y>811</Y>
+		<X>666</X>
+		<Y>831</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -777,7 +781,7 @@
 		<Id>1762940915048</Id>
 		<Name><![CDATA[f_getChargingManagement]]></Name>
 		<X>676</X>
-		<Y>621</Y>
+		<Y>641</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -793,7 +797,7 @@
 		<Id>1762940962079</Id>
 		<Name><![CDATA[f_getHeatingManagement]]></Name>
 		<X>645</X>
-		<Y>380</Y>
+		<Y>400</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -809,7 +813,7 @@
 		<Id>1765551413839</Id>
 		<Name><![CDATA[f_getChargePoint]]></Name>
 		<X>686</X>
-		<Y>681</Y>
+		<Y>701</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -825,7 +829,7 @@
 		<Id>1765551488579</Id>
 		<Name><![CDATA[f_setChargePoint]]></Name>
 		<X>686</X>
-		<Y>661</Y>
+		<Y>681</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1154,6 +1158,22 @@
 			<Name><![CDATA[assetManagementInterfaceType]]></Name>
 			<Type><![CDATA[Class<? extends I_AssetManagement> ]]></Type>
 		</Parameter>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
+	<Function AccessType="public" StaticFunction="false">
+		<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+		<ReturnType>J_HeatingPreferences</ReturnType>
+		<Id>1781165937788</Id>
+		<Name><![CDATA[f_getHeatingPreferences]]></Name>
+		<X>655</X>
+		<Y>320</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
 </Functions>

--- a/_alp/Agents/GridConnection/Variables.xml
+++ b/_alp/Agents/GridConnection/Variables.xml
@@ -394,7 +394,7 @@
 		<Id>1765551371538</Id>
 		<Name><![CDATA[p_chargePoint]]></Name>
 		<X>666</X>
-		<Y>641</Y>
+		<Y>661</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -561,7 +561,7 @@
 		<Id>1668695364192</Id>
 		<Name><![CDATA[p_batteryAsset]]></Name>
 		<X>646</X>
-		<Y>791</Y>
+		<Y>811</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -586,7 +586,7 @@
 		<Id>1676449763319</Id>
 		<Name><![CDATA[p_heatBuffer]]></Name>
 		<X>646</X>
-		<Y>771</Y>
+		<Y>791</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -611,7 +611,7 @@
 		<Id>1684919785784</Id>
 		<Name><![CDATA[p_gasBuffer]]></Name>
 		<X>646</X>
-		<Y>851</Y>
+		<Y>871</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -636,7 +636,7 @@
 		<Id>1692878211840</Id>
 		<Name><![CDATA[p_cookingTracker]]></Name>
 		<X>646</X>
-		<Y>421</Y>
+		<Y>441</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1062,7 +1062,7 @@
 		<Id>1659962626907</Id>
 		<Name><![CDATA[c_storageAssets]]></Name>
 		<X>626</X>
-		<Y>751</Y>
+		<Y>771</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1116,7 +1116,7 @@
 		<Id>1659962626913</Id>
 		<Name><![CDATA[c_conversionAssets]]></Name>
 		<X>626</X>
-		<Y>401</Y>
+		<Y>421</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1134,7 +1134,7 @@
 		<Id>1667746389220</Id>
 		<Name><![CDATA[c_vehicleAssets]]></Name>
 		<X>626</X>
-		<Y>461</Y>
+		<Y>481</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1152,7 +1152,7 @@
 		<Id>1669115948280</Id>
 		<Name><![CDATA[c_petroleumFuelVehicles]]></Name>
 		<X>646</X>
-		<Y>711</Y>
+		<Y>731</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1170,7 +1170,7 @@
 		<Id>1692864624612</Id>
 		<Name><![CDATA[c_tripTrackers]]></Name>
 		<X>646</X>
-		<Y>481</Y>
+		<Y>501</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1224,7 +1224,7 @@
 		<Id>1711012701187</Id>
 		<Name><![CDATA[c_hydrogenVehicles]]></Name>
 		<X>646</X>
-		<Y>731</Y>
+		<Y>751</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1260,7 +1260,7 @@
 		<Id>1750258408126</Id>
 		<Name><![CDATA[c_chargingSessions]]></Name>
 		<X>626</X>
-		<Y>441</Y>
+		<Y>461</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -1297,7 +1297,7 @@
 		<Id>1754581015887</Id>
 		<Name><![CDATA[c_electricVehicles]]></Name>
 		<X>646</X>
-		<Y>501</Y>
+		<Y>521</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>


### PR DESCRIPTION
See https://github.com/Zenmo/zero_Interface-Loader/pull/296 in the interface/loader

- f_addHeatManagement in the GC now takes heatingPreferences as an argument. This function used to look for an existing heatingPreferences, now this must be passed as an argument. To help with that:
- Added f_getHeatingPreferences to the GC.
- Moved some functions around on the GC canvas.