### PR TITLE
added hydrogenForTransport_kW and petroleumFuelForTransport_kW assetflow categorys

### DIFF
--- a/Zero_engine.alpx
+++ b/Zero_engine.alpx
@@ -1089,6 +1089,14 @@
 					<Id>1775831709298</Id>
 					<Name><![CDATA[hydrogenFuelCellProductionElectric_kW]]></Name>
 				</Option>
+				<Option>
+					<Id>1783332299084</Id>
+					<Name><![CDATA[hydrogenForTransport_kW]]></Name>
+				</Option>
+				<Option>
+					<Id>1783332319707</Id>
+					<Name><![CDATA[petroleumFuelForTransport_kW]]></Name>
+				</Option>
 			</OptionList>
 			<OptionList>
 				<Id>1762354709855</Id>

--- a/_alp/Classes/Class.J_EAFuelVehicle.java
+++ b/_alp/Classes/Class.J_EAFuelVehicle.java
@@ -20,10 +20,16 @@ public class J_EAFuelVehicle extends J_EAFixed implements I_Vehicle{
      * Constructor initializing the fields
      */
     public J_EAFuelVehicle(I_AssetOwner owner, double energyConsumption_kWhpkm, J_TimeParameters timeParameters, double vehicleScaling, OL_VehicleType vehicleType, J_ActivityTrackerTrips tripTracker, OL_EnergyCarriers energyCarrier ) {
-    	this(owner, energyConsumption_kWhpkm, timeParameters, vehicleScaling, vehicleType, tripTracker, energyCarrier, true );
+    	this(owner, energyConsumption_kWhpkm, timeParameters, vehicleScaling, vehicleType, tripTracker, energyCarrier, true, null);
     }
     public J_EAFuelVehicle(I_AssetOwner owner, double energyConsumption_kWhpkm, J_TimeParameters timeParameters, double vehicleScaling, OL_VehicleType vehicleType, J_ActivityTrackerTrips tripTracker, OL_EnergyCarriers energyCarrier, boolean available ) {
-	    if (energyCarrier == OL_EnergyCarriers.HEAT || energyCarrier == OL_EnergyCarriers.ELECTRICITY) {
+    	this(owner, energyConsumption_kWhpkm, timeParameters, vehicleScaling, vehicleType, tripTracker, energyCarrier, available, null );
+    }
+    public J_EAFuelVehicle(I_AssetOwner owner, double energyConsumption_kWhpkm, J_TimeParameters timeParameters, double vehicleScaling, OL_VehicleType vehicleType, J_ActivityTrackerTrips tripTracker, OL_EnergyCarriers energyCarrier, OL_AssetFlowCategories assetFlowCatagory ) {
+    	this(owner, energyConsumption_kWhpkm, timeParameters, vehicleScaling, vehicleType, tripTracker, energyCarrier, true, assetFlowCatagory);
+    }
+    public J_EAFuelVehicle(I_AssetOwner owner, double energyConsumption_kWhpkm, J_TimeParameters timeParameters, double vehicleScaling, OL_VehicleType vehicleType, J_ActivityTrackerTrips tripTracker, OL_EnergyCarriers energyCarrier, boolean available, OL_AssetFlowCategories assetFlowCatagory ) {
+    	if (energyCarrier == OL_EnergyCarriers.HEAT || energyCarrier == OL_EnergyCarriers.ELECTRICITY) {
 	    	throw new RuntimeException("Invalid choice of energy carrier for J_EAFuelVehicle");
 	    }
 		this.setOwner(owner);
@@ -38,6 +44,7 @@ public class J_EAFuelVehicle extends J_EAFixed implements I_Vehicle{
 	    	tripTracker.setVehicle(this);
 	    }
 	    
+	    this.assetFlowCategory = assetFlowCategory;
 	    this.energyCarrierConsumed = energyCarrier;
 		this.activeConsumptionEnergyCarriers.add(this.energyCarrierConsumed);
 		registerEnergyAsset(timeParameters);
@@ -46,6 +53,9 @@ public class J_EAFuelVehicle extends J_EAFixed implements I_Vehicle{
     @Override
     public J_FlowPacket f_updateAllFlows(J_TimeVariables timeVariables) {
     	flowsMap.put(this.energyCarrierConsumed, this.energyUse_kW);
+		if (this.assetFlowCategory != null) {
+			assetFlowsMap.put(this.assetFlowCategory, this.energyUse_kW);
+		}
     	J_FlowsMap flowsMapCopy = new J_FlowsMap();
      	J_ValueMap assetFlowsMapCopy = new J_ValueMap(OL_AssetFlowCategories.class);
      	J_FlowPacket flowPacket = new J_FlowPacket(flowsMapCopy.cloneMap(this.flowsMap), this.energyUse_kW, assetFlowsMapCopy.cloneMap(this.assetFlowsMap));
@@ -91,10 +101,8 @@ public class J_EAFuelVehicle extends J_EAFixed implements I_Vehicle{
 			return false;
 		}
 		else {
-			//mileage_km += marginalTripDist_km;
 	    	double energyUsedThisTimestep_kWh = marginalTripDist_km * vehicleScaling * energyConsumption_kWhpkm;
 	    	energyUsed_kWh += energyUsedThisTimestep_kWh;
-	    	//petroleumFuelConsumption_kW = energyUsedThisTimestep_kWh / timestep_h;
 	    	energyUse_kW += energyUsedThisTimestep_kWh / timeParameters.getTimeStep_h();
 			return true;
 		}

--- a/_alp/Classes/Class.J_EAFuelVehicle.java
+++ b/_alp/Classes/Class.J_EAFuelVehicle.java
@@ -25,10 +25,10 @@ public class J_EAFuelVehicle extends J_EAFixed implements I_Vehicle{
     public J_EAFuelVehicle(I_AssetOwner owner, double energyConsumption_kWhpkm, J_TimeParameters timeParameters, double vehicleScaling, OL_VehicleType vehicleType, J_ActivityTrackerTrips tripTracker, OL_EnergyCarriers energyCarrier, boolean available ) {
     	this(owner, energyConsumption_kWhpkm, timeParameters, vehicleScaling, vehicleType, tripTracker, energyCarrier, available, null );
     }
-    public J_EAFuelVehicle(I_AssetOwner owner, double energyConsumption_kWhpkm, J_TimeParameters timeParameters, double vehicleScaling, OL_VehicleType vehicleType, J_ActivityTrackerTrips tripTracker, OL_EnergyCarriers energyCarrier, OL_AssetFlowCategories assetFlowCatagory ) {
-    	this(owner, energyConsumption_kWhpkm, timeParameters, vehicleScaling, vehicleType, tripTracker, energyCarrier, true, assetFlowCatagory);
+    public J_EAFuelVehicle(I_AssetOwner owner, double energyConsumption_kWhpkm, J_TimeParameters timeParameters, double vehicleScaling, OL_VehicleType vehicleType, J_ActivityTrackerTrips tripTracker, OL_EnergyCarriers energyCarrier, OL_AssetFlowCategories assetFlowCategory ) {
+    	this(owner, energyConsumption_kWhpkm, timeParameters, vehicleScaling, vehicleType, tripTracker, energyCarrier, true, assetFlowCategory);
     }
-    public J_EAFuelVehicle(I_AssetOwner owner, double energyConsumption_kWhpkm, J_TimeParameters timeParameters, double vehicleScaling, OL_VehicleType vehicleType, J_ActivityTrackerTrips tripTracker, OL_EnergyCarriers energyCarrier, boolean available, OL_AssetFlowCategories assetFlowCatagory ) {
+    public J_EAFuelVehicle(I_AssetOwner owner, double energyConsumption_kWhpkm, J_TimeParameters timeParameters, double vehicleScaling, OL_VehicleType vehicleType, J_ActivityTrackerTrips tripTracker, OL_EnergyCarriers energyCarrier, boolean available, OL_AssetFlowCategories assetFlowCategory ) {
     	if (energyCarrier == OL_EnergyCarriers.HEAT || energyCarrier == OL_EnergyCarriers.ELECTRICITY) {
 	    	throw new RuntimeException("Invalid choice of energy carrier for J_EAFuelVehicle");
 	    }
@@ -157,8 +157,10 @@ public class J_EAFuelVehicle extends J_EAFixed implements I_Vehicle{
 	@Override
 	public String toString() {
 		return
-			"energy carrier = " + energyCarrierConsumed + " " +		
-			"energyConsumption_kWhpkm =" + energyConsumption_kWhpkm + " " +
+			"J_EAFuelVehicle: " +		
+			"EC: " + energyCarrierConsumed + "," +	
+			"AFC: " + this.assetFlowCategory + ","	+
+			"energyConsumption_kWhpkm: " + energyConsumption_kWhpkm + "," +
 			"vehicleScaling = " + vehicleScaling;
 	}
 	


### PR DESCRIPTION
Zoals met @Luc-Sol besproken: 2 asset flow categories heb ik nodig voor RES voor de boekhouding daar. Voor toekomst miss ook nice voor transport charts ofzo. 

Is nog draft! want ben benieuwd naar wat jullie van naam vinden:
hydrogenForTransport_kW en petroleumFuelForTransport_kW -> is namelijk anders dan de ev variant (evChargingPower_kW...). Willen we ze allemaal rechtrekken? zo ja, andere naam> of is het niet erg dat ev anders heet. Miss willen we sws die option list nog es refactoren, want bevat nu ook kleine letters, en dat doen we nergens anders.

-> Tot slot: Deze data hoeft nooit per tijdstap te worden opgeslagen. Misschien is daggemiddelde nog wel intteresant, zodat je kan zien welke dag van week meer gereden wordt enzo. Maar ik moet checken of dit in de rapidrun data nu niet per kwartier wordt opgeslagen (geld sws alleen voor detailed companies, energymodel en coops, want voor de rest wordt het sws nooit per kwartier opgeslagen). Voor RES is alleen jaar totaal relevant (en dat is tot nu toe dus ook enige model die deze AFC gebruikt. Wordt vervolgd.