### PR TITLE
getForecast method in EMS & Managements + Simple Charging implementation

### DIFF
--- a/Zero_engine.alpx
+++ b/Zero_engine.alpx
@@ -1316,6 +1316,26 @@ LARGE_CONNECTION (grootverbruik, > 3x80)
 					<Name><![CDATA[GROUND_WATER]]></Name>
 				</Option>
 			</OptionList>
+			<OptionList>
+				<Id>1782815749074</Id>
+				<Name><![CDATA[OL_ForecastStatus]]></Name>
+				<Option>
+					<Id>1782815757572</Id>
+					<Name><![CDATA[PERFECT_FORECAST]]></Name>
+				</Option>
+				<Option>
+					<Id>1782815764204</Id>
+					<Name><![CDATA[ESTIMATED_FORECAST]]></Name>
+				</Option>
+				<Option>
+					<Id>1782815769499</Id>
+					<Name><![CDATA[NOT_FORECASTABLE]]></Name>
+				</Option>
+				<Option>
+					<Id>1782815773730</Id>
+					<Name><![CDATA[NO_ASSETS]]></Name>
+				</Option>
+			</OptionList>
 		</OptionLists>
 		<Folders>
 			<Folder>
@@ -2270,6 +2290,11 @@ LARGE_CONNECTION (grootverbruik, > 3x80)
 				<Id>1782137734965</Id>
 				<Name><![CDATA[DataSetConstructor]]></Name>
 				<Folder>1764938574089</Folder>
+			</JavaClass>
+			<JavaClass>
+				<Id>1782811550548</Id>
+				<Name><![CDATA[J_AssetTypeForecast]]></Name>
+				<Folder>1752680962144</Folder>
 			</JavaClass>
 		</JavaClasses>
 		<RequiredLibraryReference>

--- a/_alp/Agents/EnergyModel/AOC.EnergyModel.xml
+++ b/_alp/Agents/EnergyModel/AOC.EnergyModel.xml
@@ -50,7 +50,9 @@ import com.querydsl.core.types.dsl.TimeExpression;
 //import zero_engine.J_EAStorageElectric;
 //import zero_engine.J_EAConsumption;
 
-import com.anylogic.cloud.util.DateUtils;]]></Import>
+import com.anylogic.cloud.util.DateUtils;
+
+import zero_engine.J_ActivityTrackerTrips.TripRecord;]]></Import>
 	<Implements>I_EnergyData</Implements>
 	<Generic>false</Generic>
 	<GenericParameter>

--- a/_alp/Agents/EnergyModel/Levels/Level.level.xml
+++ b/_alp/Agents/EnergyModel/Levels/Level.level.xml
@@ -1419,4 +1419,121 @@ energyDataViewer.viewArea.navigateTo();</ActionCode>
 		<Dy>0</Dy>
 		<Dz>0</Dz>
 	</Line>
+	<Control Type="Button">
+		<EmbeddedIcon>false</EmbeddedIcon>
+		<Id>1782465008753</Id>
+		<Name><![CDATA[button]]></Name>
+		<X>900</X>
+		<Y>-320</Y>
+		<Label>
+			<X>0</X>
+			<Y>-10</Y>
+		</Label>
+		<PublicFlag>true</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>false</ShowLabel>
+		<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+		<BasicProperties Width="100" Height="30">
+			<EmbeddedIcon>false</EmbeddedIcon>
+			<TextColor>-16777216</TextColor>
+			<Enabled>true</Enabled>
+			<ActionCode>traceln("index of 1 jan: %s", p_timeParameters.getDayOfWeek1jan());
+traceln("day of 1 jan: %s", p_timeParameters.getDayFromDayIndex(p_timeParameters.getDayOfWeek1jan()));
+traceln("p_timeParameters.getDayOfWeek1jan(): %s", p_timeParameters.getDayOfWeek1jan());
+traceln("p_timeParameters.getWeekIndex(12): %s", p_timeParameters.getWeekIndex(12));
+traceln("p_timeParameters.getWeekIndex(36): %s", p_timeParameters.getWeekIndex(36));
+traceln("p_timeParameters.getWeekIndex(200): %s", p_timeParameters.getWeekIndex(200));
+traceln("p_timeParameters.getWeekStart_h(0): %s", p_timeParameters.getWeekStart_h(0));
+traceln("p_timeParameters.getWeekStart_h(1): %s", p_timeParameters.getWeekStart_h(1));
+traceln("p_timeParameters.getWeekStart_h(2): %s", p_timeParameters.getWeekStart_h(2));</ActionCode>
+		</BasicProperties>
+		<ExtendedProperties>
+			<Font Name="Dialog" Size="11" Style="0"/>
+			<LabelText>Date</LabelText>
+		</ExtendedProperties>
+	</Control>
+	<Control Type="Button">
+		<EmbeddedIcon>false</EmbeddedIcon>
+		<Id>1782475157232</Id>
+		<Name><![CDATA[button1]]></Name>
+		<X>1040</X>
+		<Y>-320</Y>
+		<Label>
+			<X>0</X>
+			<Y>-10</Y>
+		</Label>
+		<PublicFlag>true</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>false</ShowLabel>
+		<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+		<BasicProperties Width="100" Height="30">
+			<EmbeddedIcon>false</EmbeddedIcon>
+			<TextColor>-16777216</TextColor>
+			<Enabled>true</Enabled>
+			<ActionCode>//GridConnection GC = findFirst(c_gridConnections, gc -&gt; gc.c_tripTrackers.size() &gt; 0);
+GridConnection GC = findFirst(c_gridConnections, gc -&gt; gc.p_gridConnectionID.equals("addressuid.school"));
+J_ActivityTrackerTrips tt = GC.c_tripTrackers.get(0);
+
+double startTime_h = 0;
+double endTime_h = 24+168;
+
+List&lt;TripRecord&gt; trips = tt.getTripsInRange(startTime_h, endTime_h);
+
+traceln(tt);
+
+for (TripRecord trip : trips) {
+	traceln("startTime: %s", trip.startTime_h());
+	traceln("endTime: %s", trip.endTime_h());
+	traceln("distance: %s", trip.distance_km());
+}</ActionCode>
+		</BasicProperties>
+		<ExtendedProperties>
+			<Font Name="Dialog" Size="11" Style="0"/>
+			<LabelText>Trips</LabelText>
+		</ExtendedProperties>
+	</Control>
+	<Control Type="Button">
+		<EmbeddedIcon>false</EmbeddedIcon>
+		<Id>1782826903548</Id>
+		<Name><![CDATA[button2]]></Name>
+		<X>1180</X>
+		<Y>-320</Y>
+		<Label>
+			<X>0</X>
+			<Y>-10</Y>
+		</Label>
+		<PublicFlag>true</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>false</ShowLabel>
+		<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+		<BasicProperties Width="100" Height="30">
+			<EmbeddedIcon>false</EmbeddedIcon>
+			<TextColor>-16777216</TextColor>
+			<Enabled>true</Enabled>
+			<ActionCode>//GridConnection GC = findFirst(c_gridConnections, gc -&gt; gc.c_tripTrackers.size() &gt; 0);
+GridConnection GC = findFirst(c_gridConnections, gc -&gt; gc.p_gridConnectionID.equals("addressuid.school"));
+
+double timeOfIntervalStart_h = 0;
+double timeOfIntervalEnd_h = 48;
+
+Map&lt;Class&lt; ? extends I_AssetManagement&gt;, J_AssetTypeForecast&gt; map = GC.f_getForecast(timeOfIntervalStart_h, timeOfIntervalEnd_h, p_timeParameters);
+
+J_AssetTypeForecast chargingForecast = map.get(I_ChargingManagement.class);
+
+traceln("chargingForecast: %s", chargingForecast);
+
+Double[] load = chargingForecast.load_kW().get(OL_EnergyCarriers.ELECTRICITY);
+
+traceln("load: ");
+for (int i = 0; i &lt; timeOfIntervalEnd_h / p_timeParameters.getTimeStep_h(); i++) {
+	double t = timeOfIntervalStart_h + i *  p_timeParameters.getTimeStep_h();
+	traceln("time t: %s, load: %s kW", t, load[i]);
+}
+</ActionCode>
+		</BasicProperties>
+		<ExtendedProperties>
+			<Font Name="Dialog" Size="11" Style="0"/>
+			<LabelText>Forecaster</LabelText>
+		</ExtendedProperties>
+	</Control>
 </Presentation>

--- a/_alp/Agents/GridConnection/Code/Functions.java
+++ b/_alp/Agents/GridConnection/Code/Functions.java
@@ -1242,3 +1242,14 @@ if(heatProfiles.size() > 0 && (f_getCurrentHeatingType() == OL_GridConnectionHea
 return nettoBalance_kW;
 /*ALCODEEND*/}
 
+Map<Class< ? extends I_AssetManagement>, J_AssetTypeForecast> f_getForecast(double timeOfIntervalStart_h,double timeOfIntervalEnd_h,J_TimeParameters timeParameters)
+{/*ALCODESTART::1782459765981*/
+if (p_energyManagement != null) {
+	return p_energyManagement.getFlexAssetForecast(timeOfIntervalStart_h, timeOfIntervalEnd_h);
+}
+
+else {
+	return new HashMap<Class<? extends I_AssetManagement>, J_AssetTypeForecast>();
+}
+/*ALCODEEND*/}
+

--- a/_alp/Agents/GridConnection/Code/Functions.xml
+++ b/_alp/Agents/GridConnection/Code/Functions.xml
@@ -1210,4 +1210,32 @@
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
+	<Function AccessType="public" StaticFunction="false">
+		<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+		<ReturnType>Map&lt;Class&lt; ? extends I_AssetManagement&gt;, J_AssetTypeForecast&gt;</ReturnType>
+		<Id>1782459765981</Id>
+		<Name><![CDATA[f_getForecast]]></Name>
+		<X>1490</X>
+		<Y>480</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Parameter>
+			<Name><![CDATA[timeOfIntervalStart_h]]></Name>
+			<Type><![CDATA[double]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[timeOfIntervalEnd_h]]></Name>
+			<Type><![CDATA[double]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[timeParameters]]></Name>
+			<Type><![CDATA[J_TimeParameters]]></Type>
+		</Parameter>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
 </Functions>

--- a/_alp/Classes/Class.I_AssetManagement.java
+++ b/_alp/Classes/Class.I_AssetManagement.java
@@ -16,5 +16,5 @@ public interface I_AssetManagement extends I_StoreStatesAndReset
 {	
 	//Get the AssetManagementInterface type (I_ChargingManagement.class, I_Heatingmanagement.class, etc.)
 	Class<? extends I_AssetManagement> getAssetManagementInterfaceType();
-	
+	J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h);
 }

--- a/_alp/Classes/Class.I_EnergyManagement.java
+++ b/_alp/Classes/Class.I_EnergyManagement.java
@@ -73,8 +73,28 @@ public interface I_EnergyManagement extends I_StoreStatesAndReset
     	return getInternalAssetManagements().contains(assetManagementType) || getSupportedExternalAssetManagements().contains(assetManagementType);
     }
     
+
+    default public Map<Class<? extends I_AssetManagement>, J_AssetTypeForecast> getFlexAssetForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+    	Map<Class<? extends I_AssetManagement>, J_AssetTypeForecast> forecasts = new HashMap<Class<? extends I_AssetManagement>, J_AssetTypeForecast>();
+    	Map<Class<? extends I_AssetManagement>, I_AssetManagement> activeExternalManagements = this.getActiveExternalAssetManagements();
+    	for (Class externalManagementClass : this.getSupportedExternalAssetManagements()) {
+    		I_AssetManagement externalManagement = activeExternalManagements.get(externalManagementClass);
+    		if (externalManagement != null) {
+    			J_AssetTypeForecast forecast = externalManagement.getForecast(timeOfIntervalStart_h, timeOfIntervalEnd_h);
+    			forecasts.put(externalManagementClass, forecast);
+    		}
+    	}
+    	for (Class internalManagementClass : this.getInternalAssetManagements()) {
+			J_AssetTypeForecast forecast = forecastInternalAssetType(internalManagementClass, timeOfIntervalStart_h, timeOfIntervalEnd_h);
+			forecasts.put(internalManagementClass, forecast);
+    	}
+    	return forecasts;
+    }
     
-    
+	default J_AssetTypeForecast forecastInternalAssetType(Class<? extends I_AssetManagement> type, double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		throw new RuntimeException("EMS declares " + type.getSimpleName() + " as an internal asset management but does not override forecastInternalAssetType() to handle it.");
+	}
+	
     ////Checks
     //Check configuration: Should be called whenever a management or asset has been removed/added/changed.
     default public void checkConfiguration(List<J_EAFlex> flexAssetsGCList) {

--- a/_alp/Classes/Class.J_ActivityTrackerTrips.java
+++ b/_alp/Classes/Class.J_ActivityTrackerTrips.java
@@ -56,7 +56,7 @@ public class J_ActivityTrackerTrips extends J_ActivityTracker {
 
       	// 'forward' to next activity
        	setStartIndex(timeVariables, chargePointRegistration);    
-   }
+    }
    
     /**
      * Constructor using defined trips as input
@@ -68,23 +68,19 @@ public class J_ActivityTrackerTrips extends J_ActivityTracker {
 
       	// 'forward' to next activity
        	setStartIndex(timeVariables, chargePointRegistration);    
-   }
+    }
     
-   private double getTimeSinceWeekStart_h(double time_h) {
-	   double timeSinceWeekStart_h = (time_h + (timeParameters.getDayOfWeek1jan()-1) * 24) % (7*24);
-	   return timeSinceWeekStart_h;
-   }
+    private double getTimeSinceWeekStart_h(double time_h) {
+    	double timeSinceWeekStart_h = (time_h + (timeParameters.getDayOfWeek1jan()-1) * 24) % (7*24);
+    	return timeSinceWeekStart_h;
+    }
     
-   private void setNextTrip() {
-	   eventIndex++;
-	   if ( eventIndex > tripRecords.size() - 1 ) {	
-	   		eventIndex = 0;
-	   }
-   }
-   
-
-      
-
+    private void setNextTrip() {
+    	eventIndex++;
+    	if ( eventIndex > tripRecords.size() - 1 ) {	
+    		eventIndex = 0;
+    	}
+    }    
     
    /*
     * Main method that is called every timestep.
@@ -93,128 +89,154 @@ public class J_ActivityTrackerTrips extends J_ActivityTracker {
     * If the vehicle is already on a trip it progresses the trip to check if the trip ends this timestep.
     * If so, it also checks if a new trip is starting in that same timestep.
     */
-   public void manageActivities(J_TimeVariables timeVariables, I_ChargePointRegistration chargePointRegistration) {
-	   double time_h = timeVariables.getT_h();
-	   double timeSinceWeekStart_h = getTimeSinceWeekStart_h(time_h); //  Trip start/end-times are all defined as minutes since monday 00:00h, trips are looped indefinitely
-	   if (vehicle.getAvailability()) { // at start of timestep! check for multiple 'events' in timestep!
-		   if ( timeSinceWeekStart_h >= tripRecords.get(eventIndex).startTime_h() && (timeSinceWeekStart_h-timeParameters.getTimeStep_h()) < tripRecords.get(eventIndex).startTime_h()) { // is a trip starting this timestep?
-			   currentTripTimesteps_n = max(1,roundToInt(((tripRecords.get(eventIndex).endTime_h() - tripRecords.get(eventIndex).startTime_h()) / (timeParameters.getTimeStep_h()))));
-			   
-			   vehicle.startTrip(timeVariables);
-			   if(vehicle instanceof J_EAEV EV) {
-				   chargePointRegistration.deregisterChargingRequest(EV);
-			   }
-			   if (timeSinceWeekStart_h >= tripRecords.get(eventIndex).endTime_h() && (timeSinceWeekStart_h-timeParameters.getTimeStep_h()) < tripRecords.get(eventIndex).endTime_h()) { // is the trip also ending this timestep?
-				   vehicle.endTrip(tripDistance_km);
-				   setNextTrip();
-				   prepareNextActivity(timeVariables, chargePointRegistration);
-			   }
-		   }
-	   } else {
-		   if (vehicle instanceof J_EAFuelVehicle fuelVehicle) {
-			   fuelVehicle.progressTrip(tripDistance_km / currentTripTimesteps_n);
-		   }
-		   if (timeSinceWeekStart_h >= tripRecords.get(eventIndex).endTime_h() && (timeSinceWeekStart_h-timeParameters.getTimeStep_h()) < tripRecords.get(eventIndex).endTime_h()) { // is a trip ending this timestep?
-			   vehicle.endTrip(tripDistance_km);
-			   setNextTrip();
-			   prepareNextActivity(timeVariables, chargePointRegistration);
-			   if (timeSinceWeekStart_h >= tripRecords.get(eventIndex).startTime_h() && (timeSinceWeekStart_h-timeParameters.getTimeStep_h()) < tripRecords.get(eventIndex).startTime_h() ) { // is the next trip also starting this timestep?
-				   currentTripTimesteps_n = max(1,roundToInt(((tripRecords.get(eventIndex).endTime_h() - tripRecords.get(eventIndex).startTime_h()) / timeParameters.getTimeStep_h())));
-				   vehicle.startTrip(timeVariables);
-				   if(vehicle instanceof J_EAEV EV) {
-					   chargePointRegistration.deregisterChargingRequest(EV);
-				   }
-			   }
-		   }
-	   }
-   }
+    public void manageActivities(J_TimeVariables timeVariables, I_ChargePointRegistration chargePointRegistration) {
+    	double time_h = timeVariables.getT_h();
+    	double timeSinceWeekStart_h = getTimeSinceWeekStart_h(time_h); //  Trip start/end-times are all defined as minutes since monday 00:00h, trips are looped indefinitely
+    	if (vehicle.getAvailability()) { // at start of timestep! check for multiple 'events' in timestep!
+    		if ( timeSinceWeekStart_h >= tripRecords.get(eventIndex).startTime_h() && (timeSinceWeekStart_h-timeParameters.getTimeStep_h()) < tripRecords.get(eventIndex).startTime_h()) { // is a trip starting this timestep?
+    			currentTripTimesteps_n = max(1,roundToInt(((tripRecords.get(eventIndex).endTime_h() - tripRecords.get(eventIndex).startTime_h()) / (timeParameters.getTimeStep_h()))));
+    			
+    			vehicle.startTrip(timeVariables);
+    			if(vehicle instanceof J_EAEV EV) {
+    				chargePointRegistration.deregisterChargingRequest(EV);
+    			}
+    			if (timeSinceWeekStart_h >= tripRecords.get(eventIndex).endTime_h() && (timeSinceWeekStart_h-timeParameters.getTimeStep_h()) < tripRecords.get(eventIndex).endTime_h()) { // is the trip also ending this timestep?
+    				vehicle.endTrip(tripDistance_km);
+    				setNextTrip();
+    				prepareNextActivity(timeVariables, chargePointRegistration);
+    			}
+    		}
+    	} else {
+    		if (vehicle instanceof J_EAFuelVehicle fuelVehicle) {
+    			fuelVehicle.progressTrip(tripDistance_km / currentTripTimesteps_n);
+    		}
+    		if (timeSinceWeekStart_h >= tripRecords.get(eventIndex).endTime_h() && (timeSinceWeekStart_h-timeParameters.getTimeStep_h()) < tripRecords.get(eventIndex).endTime_h()) { // is a trip ending this timestep?
+    			vehicle.endTrip(tripDistance_km);
+    			setNextTrip();
+    			prepareNextActivity(timeVariables, chargePointRegistration);
+    			if (timeSinceWeekStart_h >= tripRecords.get(eventIndex).startTime_h() && (timeSinceWeekStart_h-timeParameters.getTimeStep_h()) < tripRecords.get(eventIndex).startTime_h() ) { // is the next trip also starting this timestep?
+    				currentTripTimesteps_n = max(1,roundToInt(((tripRecords.get(eventIndex).endTime_h() - tripRecords.get(eventIndex).startTime_h()) / timeParameters.getTimeStep_h())));
+    				vehicle.startTrip(timeVariables);
+    				if(vehicle instanceof J_EAEV EV) {
+    					chargePointRegistration.deregisterChargingRequest(EV);
+    				}
+    			}
+    		}
+    	}
+    }
    
-   /*
-    * This method 'Forwards' to the activity at time in timeVariables
-    * It also immediately calls prepareNextActivity
-    */
-   public void setStartIndex(J_TimeVariables timeVariables, I_ChargePointRegistration chargePointRegistration) {
-	   double time_h = timeVariables.getT_h();
-	   double timeSinceWeekStart_h = getTimeSinceWeekStart_h(time_h);
-	   boolean looped = false;
-	   while ( tripRecords.get(eventIndex).startTime_h() < (timeSinceWeekStart_h ) ) { // If this occurs 'during' a trip, that trip is ignored, it is not executed.
-		   setNextTrip(); // Skip to the next trip.
-		   
-		   if (eventIndex == tripRecords.size()-1 ) { 
-			   if (looped) {
-				   setNextTrip(); // Increments eventIndex, reverts to first trip of week when 'overflowing'
-				   break;
-			   } else {
-				   looped = true;
-			   }
-		   }
-	   }
-	   prepareNextActivity(timeVariables, chargePointRegistration);    	
-   }
+    /*
+     * This method 'Forwards' to the activity at time in timeVariables
+     * It also immediately calls prepareNextActivity
+     */
+    public void setStartIndex(J_TimeVariables timeVariables, I_ChargePointRegistration chargePointRegistration) {
+    	double time_h = timeVariables.getT_h();
+    	double timeSinceWeekStart_h = getTimeSinceWeekStart_h(time_h);
+    	boolean looped = false;
+    	while ( tripRecords.get(eventIndex).startTime_h() < (timeSinceWeekStart_h ) ) { // If this occurs 'during' a trip, that trip is ignored, it is not executed.
+    		setNextTrip(); // Skip to the next trip.
+    		
+    		if (eventIndex == tripRecords.size()-1 ) { 
+    			if (looped) {
+    				setNextTrip(); // Increments eventIndex, reverts to first trip of week when 'overflowing'
+    				break;
+    			} else {
+    				looped = true;
+    			}
+    		}
+    	}
+    	prepareNextActivity(timeVariables, chargePointRegistration);    	
+    }
    
-   /*
-    * This method is called after the previous trip ended.
-    * It calculates the time to and distance of the coming trip.
-    * If the vehicle is an EV it also calculates the charging need, including possible future trips.
-    * The function passes this information to the EV and registers the charging request at the chargepoint.
-    */
-   public void prepareNextActivity(J_TimeVariables timeVariables, I_ChargePointRegistration chargePointRegistration) {
-	   double time_h = timeVariables.getT_h();
-	   
-	   // Trip start/end-times are all defined as hours since monday 00:00h
-	   double timeSinceWeekStart_h = getTimeSinceWeekStart_h(time_h);
-	   nextEventStartTime_h = tripRecords.get(eventIndex).startTime_h();
-	   
-	   if (eventIndex == 0 && timeSinceWeekStart_h > nextEventStartTime_h) { // Next week's trip!
-		   nextEventStartTime_h = (nextEventStartTime_h + time_h - timeSinceWeekStart_h) + 168;
-	   } else {
-		   nextEventStartTime_h = (nextEventStartTime_h + time_h - timeSinceWeekStart_h);
-	   }
-	   idleTimeToNextTrip_h = (nextEventStartTime_h - timeSinceWeekStart_h) % (24*7); // Modulo 24*7 needed because otherwise negative values can occur when trip starts 'next week'.
-	   tripDistance_km = distanceScaling_fr * tripRecords.get(eventIndex).distance_km(); // Update upcoming trip distance
-	   
-	   if (vehicle instanceof J_EAEV ev) {
-		   
-		   double energyNeedForNextTrip_kWh = ev.getEnergyConsumption_kWhpkm() * tripDistance_km;
-		   if (idleTimeToNextTrip_h > 0 && (energyNeedForNextTrip_kWh-ev.getCurrentSOC_kWh())> idleTimeToNextTrip_h * ev.getVehicleChargingCapacity_kW()) {
-			   traceln("TripTracker reports: charging need for next trip is not feasible! Time till next trip: %s hours, chargeNeed_kWh: %s", roundToDecimal(idleTimeToNextTrip_h,2), roundToDecimal(energyNeedForNextTrip_kWh-ev.getCurrentSOC_kWh(),2));
-		   }
-		   // Check if more charging is needed for next trip!
-		   double nextTripDist_km = 0;
-		   double nextTripStartTime_h = 0;
-		   
-		   if ( eventIndex == tripRecords.size() - 1 ) {
-			   nextTripDist_km = tripRecords.get(0).distance_km();
-			   nextTripStartTime_h = tripRecords.get(0).endTime_h();
-		   } else {		
-			   nextTripDist_km = distanceScaling_fr*tripRecords.get(eventIndex+1).distance_km();
-			   nextTripStartTime_h = tripRecords.get(eventIndex+1).startTime_h();
-		   }
-		   double additionalChargingNeededForNextTrip_kWh = max(0,nextTripDist_km * ev.getEnergyConsumption_kWhpkm() - (nextTripStartTime_h - tripRecords.get(eventIndex).endTime_h())*ev.getVehicleChargingCapacity_kW());
-		   
-		   energyNeedForNextTrip_kWh += additionalChargingNeededForNextTrip_kWh;
-		   energyNeedForNextTrip_kWh = min(energyNeedForNextTrip_kWh+10,ev.getStorageCapacity_kWh());
-		   ev.setEnergyNeedForNextTrip_kWh(energyNeedForNextTrip_kWh);
-	   
-		   //Register EV at the chargepoint
-		   chargePointRegistration.registerChargingRequest(ev);
-	   }
-   }
+    /*
+     * This method is called after the previous trip ended.
+     * It calculates the time to and distance of the coming trip.
+     * If the vehicle is an EV it also calculates the charging need, including possible future trips.
+     * The function passes this information to the EV and registers the charging request at the chargepoint.
+     */
+    public void prepareNextActivity(J_TimeVariables timeVariables, I_ChargePointRegistration chargePointRegistration) {
+    	double time_h = timeVariables.getT_h();
+    	
+    	// Trip start/end-times are all defined as hours since monday 00:00h
+    	double timeSinceWeekStart_h = getTimeSinceWeekStart_h(time_h);
+    	nextEventStartTime_h = tripRecords.get(eventIndex).startTime_h();
+    	
+    	if (eventIndex == 0 && timeSinceWeekStart_h > nextEventStartTime_h) { // Next week's trip!
+    		nextEventStartTime_h = (nextEventStartTime_h + time_h - timeSinceWeekStart_h) + 168;
+    	} else {
+    		nextEventStartTime_h = (nextEventStartTime_h + time_h - timeSinceWeekStart_h);
+    	}
+    	idleTimeToNextTrip_h = (nextEventStartTime_h - timeSinceWeekStart_h) % (24*7); // Modulo 24*7 needed because otherwise negative values can occur when trip starts 'next week'.
+    	tripDistance_km = distanceScaling_fr * tripRecords.get(eventIndex).distance_km(); // Update upcoming trip distance
+    	
+    	if (vehicle instanceof J_EAEV ev) {
+    		
+    		double energyNeedForNextTrip_kWh = ev.getEnergyConsumption_kWhpkm() * tripDistance_km;
+    		if (idleTimeToNextTrip_h > 0 && (energyNeedForNextTrip_kWh-ev.getCurrentSOC_kWh())> idleTimeToNextTrip_h * ev.getVehicleChargingCapacity_kW()) {
+    			traceln("TripTracker reports: charging need for next trip is not feasible! Time till next trip: %s hours, chargeNeed_kWh: %s", roundToDecimal(idleTimeToNextTrip_h,2), roundToDecimal(energyNeedForNextTrip_kWh-ev.getCurrentSOC_kWh(),2));
+    		}
+    		// Check if more charging is needed for next trip!
+    		double nextTripDist_km = 0;
+    		double nextTripStartTime_h = 0;
+    		
+    		if ( eventIndex == tripRecords.size() - 1 ) {
+    			nextTripDist_km = tripRecords.get(0).distance_km();
+    			nextTripStartTime_h = tripRecords.get(0).endTime_h();
+    		} else {		
+    			nextTripDist_km = distanceScaling_fr*tripRecords.get(eventIndex+1).distance_km();
+    			nextTripStartTime_h = tripRecords.get(eventIndex+1).startTime_h();
+    		}
+    		double additionalChargingNeededForNextTrip_kWh = max(0,nextTripDist_km * ev.getEnergyConsumption_kWhpkm() - (nextTripStartTime_h - tripRecords.get(eventIndex).endTime_h())*ev.getVehicleChargingCapacity_kW());
+    		
+    		energyNeedForNextTrip_kWh += additionalChargingNeededForNextTrip_kWh;
+    		energyNeedForNextTrip_kWh = min(energyNeedForNextTrip_kWh+10,ev.getStorageCapacity_kWh());
+    		ev.setEnergyNeedForNextTrip_kWh(energyNeedForNextTrip_kWh);
+    		
+    		//Register EV at the chargepoint
+    		chargePointRegistration.registerChargingRequest(ev);
+    	}
+    }
+   
+    /*
+     * This method returns a list of trips,
+     * The included trips are those that have a startTime within the range of [startTime_h, endTime_h)
+     * For each of these start times the TripRecord includes the distance for that upcoming trip, which the J_EAEV can translate into required energy.
+     * The times in the TripRecords are 'absolute', i.e. relative to the first of January.
+     */
+    public List<TripRecord> getTripsInRange( double startTime_h, double endTime_h ) {
+    	List<TripRecord> trips = new ArrayList<>();
+    	if (endTime_h < startTime_h) {
+    		// Could return an empty list instead, but prefer to throw an exception to hint at something going wrong.
+    		throw new RuntimeException(String.format("Could not get trips in range [ %s, %s ), since startTime is after endTime_h", startTime_h, endTime_h));
+    	}
+    	int startWeek = this.timeParameters.getWeekIndex(startTime_h);
+    	int endWeek   = this.timeParameters.getWeekIndex(endTime_h);
+    	for (int week = startWeek; week <= endWeek; week++) {
+    		double weekStartTime_h = this.timeParameters.getWeekStart_h(week);
+    		for (TripRecord trip : tripRecords) {
+    			double absStart = weekStartTime_h + trip.startTime_h();
+    			double absEnd   = weekStartTime_h + trip.endTime_h();
+    			if (absStart >= startTime_h && absStart < endTime_h) {
+    				trips.add(new TripRecord(absStart, absEnd, trip.distance_km()));
+    			}
+    		}
+    	}
+    	return trips;
+    }
     
-   
-   //Setters
-   public void setVehicle(I_Vehicle vehicle) {
-	   this.vehicle = vehicle;
-   }
-   public void setDistanceScaling_fr(double distanceScaling_fr) {
-	   this.distanceScaling_fr = distanceScaling_fr;
-   }
-   public void setAnnualDistance_km(double desiredAnnualDistance_km) { // Scale trips to come to a certain total annual distance traveled. This can lead to unfeasibly long trips for EVs!!
-	   double currentAnnualDistance_km = getAnnualDistance_km();
-	   double scalingFactor_f = desiredAnnualDistance_km / currentAnnualDistance_km;
-	   
-	    ListIterator<TripRecord> iterator = tripRecords.listIterator();
-	    while (iterator.hasNext()) {
+    //Setters
+    public void setVehicle(I_Vehicle vehicle) {
+    	this.vehicle = vehicle;
+    }
+    public void setDistanceScaling_fr(double distanceScaling_fr) {
+    	this.distanceScaling_fr = distanceScaling_fr;
+    }
+    public void setAnnualDistance_km(double desiredAnnualDistance_km) { // Scale trips to come to a certain total annual distance traveled. This can lead to unfeasibly long trips for EVs!!
+    	double currentAnnualDistance_km = getAnnualDistance_km();
+    	double scalingFactor_f = desiredAnnualDistance_km / currentAnnualDistance_km;
+    	
+    	ListIterator<TripRecord> iterator = tripRecords.listIterator();
+    	while (iterator.hasNext()) {
 	        TripRecord record = iterator.next();
 	        iterator.set(new TripRecord(
 	            record.startTime_h(),
@@ -222,48 +244,52 @@ public class J_ActivityTrackerTrips extends J_ActivityTracker {
 	            record.distance_km() * scalingFactor_f
 	        ));
 	    }
-   }
-   //Getters
-   public I_Vehicle getVehicle() {
-	   return this.vehicle;
-   }
-   public double getNextEventStartTime_h() {
-	   return nextEventStartTime_h;
-   }
-   
-   public double getDistanceScaling_fr( ) {
-	   return this.distanceScaling_fr;
-   }
-   public double getAnnualDistance_km() {
-	    double currentAnnualDistance_km = 52 * tripRecords.stream().mapToDouble(TripRecord::distance_km).sum(); // assumed trip-data is one week long!! Hence the 52, for 52 weeks in a year.
-	    return currentAnnualDistance_km;
-   }
-   
-   public static record TripRecord(double startTime_h, double endTime_h, double distance_km) {
-   }
-   
-   @Override
-   public void storeStatesAndReset() {
-	   eventIndexStored = eventIndex;
-	   nextEventStartTimeStored_h = nextEventStartTime_h;
-	   idleTimeToNextTripStored_h = idleTimeToNextTrip_h;
-	   idleTimeToNextTrip_h = 0;
-	   // Don't forget to call setStartIndex !
-   }
-
-   @Override
-   public void restoreStates() {
-	   eventIndex = eventIndexStored;
-	   nextEventStartTime_h = nextEventStartTimeStored_h;
-	   idleTimeToNextTrip_h = idleTimeToNextTripStored_h;
-	   tripDistance_km = distanceScaling_fr * tripRecords.get(eventIndex).distance_km(); // Update upcoming trip distance
-   }
-
-   @Override
-   public String toString() {
-	   String outputString =  "J_ActivityTrackerTrips: \n";
-	   outputString += "Based on " + (CSVRowIndex != null ? "CSV data with row index: " + CSVRowIndex : "Custom input") + "\n";
-	   outputString += "Distance Scaling = " + this.distanceScaling_fr + " ";		
-	   return outputString;
-   }
+    }
+    //Getters
+    public I_Vehicle getVehicle() {
+    	return this.vehicle;
+    }
+    public double getNextEventStartTime_h() {
+    	return nextEventStartTime_h;
+    }
+    
+    public double getCurrentTripEndTime_h() {
+    	return this.tripRecords.get(eventIndex).endTime_h();
+    }
+    
+    public double getDistanceScaling_fr( ) {
+    	return this.distanceScaling_fr;
+    }
+    public double getAnnualDistance_km() {
+    	double currentAnnualDistance_km = 52 * tripRecords.stream().mapToDouble(TripRecord::distance_km).sum(); // assumed trip-data is one week long!! Hence the 52, for 52 weeks in a year.
+    	return currentAnnualDistance_km;
+    }
+    
+    public static record TripRecord(double startTime_h, double endTime_h, double distance_km) {}
+    
+    
+    @Override
+    public void storeStatesAndReset() {
+    	eventIndexStored = eventIndex;
+    	nextEventStartTimeStored_h = nextEventStartTime_h;
+    	idleTimeToNextTripStored_h = idleTimeToNextTrip_h;
+    	idleTimeToNextTrip_h = 0;
+    	// Don't forget to call setStartIndex !
+    }
+    
+	@Override
+	public void restoreStates() {
+		eventIndex = eventIndexStored;
+		nextEventStartTime_h = nextEventStartTimeStored_h;
+		idleTimeToNextTrip_h = idleTimeToNextTripStored_h;
+		tripDistance_km = distanceScaling_fr * tripRecords.get(eventIndex).distance_km(); // Update upcoming trip distance
+	}
+	
+	@Override
+	public String toString() {
+		String outputString =  "J_ActivityTrackerTrips: \n";
+		outputString += "Based on " + (CSVRowIndex != null ? "CSV data with row index: " + CSVRowIndex : "Custom input") + "\n";
+		outputString += "Distance Scaling = " + this.distanceScaling_fr + " ";		
+		return outputString;
+	}
 }

--- a/_alp/Classes/Class.J_AssetTypeForecast.java
+++ b/_alp/Classes/Class.J_AssetTypeForecast.java
@@ -1,0 +1,9 @@
+/**
+ * J_AssetTypeForecast
+ */	
+public record J_AssetTypeForecast(
+	    Class<? extends I_AssetManagement> assetType,
+	    Map<OL_EnergyCarriers, Double[]> load_kW,
+	    OL_ForecastStatus status,
+	    String reason // Optional field to give an explanation for the status
+) {}

--- a/_alp/Classes/Class.J_BackupGeneratorManagementContractCapacity.java
+++ b/_alp/Classes/Class.J_BackupGeneratorManagementContractCapacity.java
@@ -37,6 +37,13 @@ public class J_BackupGeneratorManagementContractCapacity implements I_BackupGene
     	}
     }
     
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_BackupGeneratorManagement.class, loadMap, status, reason);
+	}
+    
     ////Store and reset states
 	public void storeStatesAndReset() {
 		//Nothing to store and reset

--- a/_alp/Classes/Class.J_BackupGeneratorManagementExternalSetpoint.java
+++ b/_alp/Classes/Class.J_BackupGeneratorManagementExternalSetpoint.java
@@ -41,6 +41,13 @@ public class J_BackupGeneratorManagementExternalSetpoint implements I_BackupGene
     	this.backupGeneratorPowerSetpoint_kW = backupGeneratorPowerSetpoint_kW;
     }
     
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "External Setpoint Management can not be forecasted.";
+		return new J_AssetTypeForecast(I_BackupGeneratorManagement.class, loadMap, status, reason);
+	}
+	
     ////Store and reset states
 	public void storeStatesAndReset() {
 		//Nothing to store and reset

--- a/_alp/Classes/Class.J_BatteryManagementExternalSetpoint.java
+++ b/_alp/Classes/Class.J_BatteryManagementExternalSetpoint.java
@@ -53,7 +53,12 @@ public class J_BatteryManagementExternalSetpoint implements I_BatteryManagement 
 	    }
     }
     
-    
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "External Setpoint Management can not be forecasted.";
+		return new J_AssetTypeForecast(I_BatteryManagement.class, loadMap, status, reason);
+	}
     
     //Get parentagent
     public Agent getParentAgent() {

--- a/_alp/Classes/Class.J_BatteryManagementLocalBalancing.java
+++ b/_alp/Classes/Class.J_BatteryManagementLocalBalancing.java
@@ -70,6 +70,13 @@ public class J_BatteryManagementLocalBalancing implements I_BatteryManagement {
 	    	gc.f_updateFlexAssetFlows(gc.p_batteryAsset, chargeSetpoint_kW / gc.p_batteryAsset.getCapacityElectric_kW(), timeVariables);
 	    }
     }
+    
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_BatteryManagement.class, loadMap, status, reason);
+	}
   
     private double getDeliveryCapacity_kW() {
     	return gc.v_liveConnectionMetaData.getContractedDeliveryCapacity_kW();

--- a/_alp/Classes/Class.J_BatteryManagementOff.java
+++ b/_alp/Classes/Class.J_BatteryManagementOff.java
@@ -36,9 +36,15 @@ public class J_BatteryManagementOff implements I_BatteryManagement {
     	}
     }
     
-
-	
-	
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		int timeStepsInForecast = roundToInt((timeOfIntervalEnd_h - timeOfIntervalStart_h) / this.timeParameters.getTimeStep_h());
+		Double[] electricityLoad_kW = new Double[timeStepsInForecast];
+		Arrays.fill(electricityLoad_kW, 0.0);
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		loadMap.put(OL_EnergyCarriers.ELECTRICITY, electricityLoad_kW);
+		OL_ForecastStatus status = OL_ForecastStatus.PERFECT_FORECAST;
+		return new J_AssetTypeForecast(I_BatteryManagement.class, loadMap, status, null);
+	}
 	
     //Get parentagent
     public Agent getParentAgent() {

--- a/_alp/Classes/Class.J_BatteryManagementPeakShaving.java
+++ b/_alp/Classes/Class.J_BatteryManagementPeakShaving.java
@@ -149,8 +149,12 @@ public class J_BatteryManagementPeakShaving implements I_BatteryManagement {
     	}
     }
     
-    
-    
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_BatteryManagement.class, loadMap, status, reason);
+	}    
     
     //Get parentagent
     public Agent getParentAgent() {

--- a/_alp/Classes/Class.J_BatteryManagementPeakShavingForecast.java
+++ b/_alp/Classes/Class.J_BatteryManagementPeakShavingForecast.java
@@ -198,7 +198,12 @@ public class J_BatteryManagementPeakShavingForecast implements I_BatteryManageme
     	this.initializeAssets();
     }
 
-	
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_BatteryManagement.class, loadMap, status, reason);
+	}
 	
     //Get parentagent
     public Agent getParentAgent() {

--- a/_alp/Classes/Class.J_BatteryManagementPrice.java
+++ b/_alp/Classes/Class.J_BatteryManagementPrice.java
@@ -90,8 +90,12 @@ public class J_BatteryManagementPrice implements I_BatteryManagement {
     	}
     }
     
-    
-    
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_BatteryManagement.class, loadMap, status, reason);
+	}
     
     //Get parentagent
     public Agent getParentAgent() {

--- a/_alp/Classes/Class.J_BatteryManagementProfile.java
+++ b/_alp/Classes/Class.J_BatteryManagementProfile.java
@@ -61,6 +61,13 @@ public class J_BatteryManagementProfile implements I_BatteryManagement {
     	}
     }
     
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_BatteryManagement.class, loadMap, status, reason);
+	}
+	
     //Get parentagent
     public Agent getParentAgent() {
     	return this.gc;

--- a/_alp/Classes/Class.J_BatteryManagementSelfConsumption.java
+++ b/_alp/Classes/Class.J_BatteryManagementSelfConsumption.java
@@ -42,8 +42,12 @@ public class J_BatteryManagementSelfConsumption implements I_BatteryManagement {
     	}
     }
 
-    
-    
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_BatteryManagement.class, loadMap, status, reason);
+	}
     
     //Get parentagent
     public Agent getParentAgent() {

--- a/_alp/Classes/Class.J_BatteryManagementSelfConsumptionGridNode.java
+++ b/_alp/Classes/Class.J_BatteryManagementSelfConsumptionGridNode.java
@@ -45,7 +45,12 @@ public class J_BatteryManagementSelfConsumptionGridNode implements I_BatteryMana
     	}
     }
     
-    
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_BatteryManagement.class, loadMap, status, reason);
+	}
     
     //Get parentagent
     public Agent getParentAgent() {

--- a/_alp/Classes/Class.J_ChargingManagementExternalSetpoint.java
+++ b/_alp/Classes/Class.J_ChargingManagementExternalSetpoint.java
@@ -56,6 +56,13 @@ public class J_ChargingManagementExternalSetpoint implements I_ChargingManagemen
     	map_chargingSetpoints_kW = new HashMap<>();
     }
     
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "External Setpoint Management can not be forecasted.";
+		return new J_AssetTypeForecast(I_ChargingManagement.class, loadMap, status, reason);
+	}
+	
 	public void setChargingSetpoints(Map<I_ChargingRequest, Double> map_chargingSetpoints_kW) {
 		this.map_chargingSetpoints_kW = map_chargingSetpoints_kW;
 	}

--- a/_alp/Classes/Class.J_ChargingManagementGridBalancing.java
+++ b/_alp/Classes/Class.J_ChargingManagementGridBalancing.java
@@ -75,6 +75,13 @@ public class J_ChargingManagementGridBalancing implements I_ChargingManagement {
     	}
     }
     
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_ChargingManagement.class, loadMap, status, reason);
+	}
+	
 	public void setV2GActive(boolean activateV2G) {
 		this.V2GActive = activateV2G;
 		this.gc.c_electricVehicles.forEach(ev -> ev.setV2GActive(activateV2G)); // NEEDED TO HAVE EV ASSET IN CORRECT assetFlowCatagory

--- a/_alp/Classes/Class.J_ChargingManagementLocalBalancing.java
+++ b/_alp/Classes/Class.J_ChargingManagementLocalBalancing.java
@@ -73,6 +73,13 @@ public class J_ChargingManagementLocalBalancing implements I_ChargingManagement 
     	}
     }
 
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_ChargingManagement.class, loadMap, status, reason);
+	}
+	
 	public void setV2GActive(boolean activateV2G) {
 		this.V2GActive = activateV2G;
 		this.gc.c_electricVehicles.forEach(ev -> ev.setV2GActive(activateV2G)); // NEEDED TO HAVE EV ASSET IN CORRECT assetFlowCatagory

--- a/_alp/Classes/Class.J_ChargingManagementMaxAvailablePower.java
+++ b/_alp/Classes/Class.J_ChargingManagementMaxAvailablePower.java
@@ -69,6 +69,13 @@ public class J_ChargingManagementMaxAvailablePower implements I_ChargingManageme
     	}
     }
     
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_ChargingManagement.class, loadMap, status, reason);
+	}
+	
 	public void setV2GActive(boolean activateV2G) {
 		this.V2GActive = activateV2G;
 		this.gc.c_electricVehicles.forEach(ev -> ev.setV2GActive(activateV2G)); // NEEDED TO HAVE EV ASSET IN CORRECT assetFlowCatagory
@@ -78,9 +85,6 @@ public class J_ChargingManagementMaxAvailablePower implements I_ChargingManageme
 	public boolean getV2GActive() {
 		return this.V2GActive;
 	}
-	
-	
-	
 	
     //Get parentagent
     public Agent getParentAgent() {

--- a/_alp/Classes/Class.J_ChargingManagementOffPeak.java
+++ b/_alp/Classes/Class.J_ChargingManagementOffPeak.java
@@ -89,6 +89,13 @@ public class J_ChargingManagementOffPeak implements I_ChargingManagement {
     	}
     }
 
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_ChargingManagement.class, loadMap, status, reason);
+	}
+	
     public void setStartTimeOfReducedChargingInterval_hr(double startTimeOfReducedChargingInterval_hr) {
     	this.startTimeOfReducedChargingInterval_hr = startTimeOfReducedChargingInterval_hr;
     }

--- a/_alp/Classes/Class.J_ChargingManagementPrice.java
+++ b/_alp/Classes/Class.J_ChargingManagementPrice.java
@@ -70,6 +70,13 @@ public class J_ChargingManagementPrice implements I_ChargingManagement {
     	}
     }
 
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_ChargingManagement.class, loadMap, status, reason);
+	}
+	
 	public void setV2GActive(boolean activateV2G) {
 		this.V2GActive = activateV2G;
 		this.gc.c_electricVehicles.forEach(ev -> ev.setV2GActive(activateV2G)); // NEEDED TO HAVE EV ASSET IN CORRECT assetFlowCatagory

--- a/_alp/Classes/Class.J_ChargingManagementPriceScheduled.java
+++ b/_alp/Classes/Class.J_ChargingManagementPriceScheduled.java
@@ -150,6 +150,13 @@ public class J_ChargingManagementPriceScheduled implements I_ChargingManagement 
 		}       					
 		activeSessions.removeIf(session -> session.isFinished); // Must be outside of for-loop over this collection!
     }
+    
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_ChargingManagement.class, loadMap, status, reason);
+	}
 
     public void abortSession(I_ChargingRequest chargingRequest) {
     	previousChargingRequests.remove(chargingRequest);

--- a/_alp/Classes/Class.J_ChargingManagementSimple.java
+++ b/_alp/Classes/Class.J_ChargingManagementSimple.java
@@ -4,6 +4,9 @@
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+
+import zero_engine.J_ActivityTrackerTrips.TripRecord;
+
 import java.util.EnumSet;
 
 @JsonAutoDetect(
@@ -50,6 +53,76 @@ public class J_ChargingManagementSimple implements I_ChargingManagement {
     		chargePoint.charge(chargingRequest, chargePoint.getMaxChargingCapacity_kW(chargingRequest), timeVariables, gc);
     	}
     }
+    
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		// TODO: Check if this works for (public) charging sessions aswell
+		int timeStepsInForecast = roundToInt((timeOfIntervalEnd_h - timeOfIntervalStart_h) / this.timeParameters.getTimeStep_h());
+		Double[] electricityLoad_kW = new Double[timeStepsInForecast];
+		Arrays.fill(electricityLoad_kW, 0.0);
+		
+		for (J_EAEV ev : this.gc.c_electricVehicles) {
+	    	double[] EVLoad_kW = new double[timeStepsInForecast];
+			J_ActivityTrackerTrips tripTracker = ev.getTripTracker();
+			List<TripRecord> trips = tripTracker.getTripsInRange(timeOfIntervalStart_h, timeOfIntervalEnd_h);
+	    	
+			double maximalStorageCapacity_kWh = ev.getStorageCapacity_kWh();
+			double currentSOC_kWh = ev.getCurrentSOC_kWh(); // Assumes the SOC of the EV at start of forecast is current SOC
+		    double work_kWh = maximalStorageCapacity_kWh - currentSOC_kWh;
+	    	double endTimeLastTrip_h = ev.getAvailability() ? 0.0 : tripTracker.getCurrentTripEndTime_h()%24; // Assumes the current trip ends today, i.e. no trips > 24 hours exist)
+    		double firstAvailableChargingTime_h = this.timeParameters.getTimeStep_h() * Math.ceil(endTimeLastTrip_h / this.timeParameters.getTimeStep_h());
+    		double startTimeNextTrip_h = trips.size() > 0 ? trips.get(0).startTime_h() : timeOfIntervalEnd_h;
+    		double lastAvailableChargingTime_h = this.timeParameters.getTimeStep_h() * Math.floor(startTimeNextTrip_h / this.timeParameters.getTimeStep_h());
+    		double maxPower_kW = ev.getVehicleChargingCapacity_kW();
+    		double maxWork_kWh = (lastAvailableChargingTime_h - firstAvailableChargingTime_h) * maxPower_kW;
+    		double initialWork_kWh = max(0, min(work_kWh, maxWork_kWh));
+    		double remainingWork_kWh = initialWork_kWh;
+    		for (int i = 0; i < timeStepsInForecast; i++) {
+    			double t = i*this.timeParameters.getTimeStep_h();
+    			if (t >= firstAvailableChargingTime_h && t <= lastAvailableChargingTime_h) {  // >= or > ?
+    				EVLoad_kW[i] = max(0, min(maxPower_kW, remainingWork_kWh / this.timeParameters.getTimeStep_h()));
+    				remainingWork_kWh -= EVLoad_kW[i] * this.timeParameters.getTimeStep_h();
+    				if (remainingWork_kWh == 0 || DoubleCompare.lessThanZero(remainingWork_kWh)) {
+    					break;
+    				}
+    			}
+    		}
+    		currentSOC_kWh += initialWork_kWh - remainingWork_kWh;
+		    
+	    	for (int tripIndex = 0; tripIndex < trips.size(); tripIndex++) {
+	    		TripRecord trip = trips.get(tripIndex);
+	    		double distance_km = trip.distance_km();
+	    		currentSOC_kWh -= distance_km * ev.getEnergyConsumption_kWhpkm();
+	    		work_kWh = maximalStorageCapacity_kWh - currentSOC_kWh;    		
+	    		endTimeLastTrip_h = trip.endTime_h();
+	    		firstAvailableChargingTime_h = this.timeParameters.getTimeStep_h() * Math.ceil(endTimeLastTrip_h / this.timeParameters.getTimeStep_h());
+	    		startTimeNextTrip_h = (tripIndex == trips.size() - 1) ? timeOfIntervalEnd_h : trips.get(tripIndex+1).startTime_h();
+	    		lastAvailableChargingTime_h = this.timeParameters.getTimeStep_h() * Math.floor(startTimeNextTrip_h / this.timeParameters.getTimeStep_h());
+	    		maxWork_kWh = (lastAvailableChargingTime_h - firstAvailableChargingTime_h) * maxPower_kW;
+	    		initialWork_kWh = max(0, min(work_kWh, maxWork_kWh));
+	    		remainingWork_kWh = initialWork_kWh;
+	    		for (int i = 0; i < timeStepsInForecast; i++) {
+	    			double t = i*this.timeParameters.getTimeStep_h();
+	    			if (t >= firstAvailableChargingTime_h && t <= lastAvailableChargingTime_h) {  // >= or > ?
+	    				EVLoad_kW[i] = max(0, min(maxPower_kW, remainingWork_kWh / this.timeParameters.getTimeStep_h()));
+	    				remainingWork_kWh -= EVLoad_kW[i] * this.timeParameters.getTimeStep_h();
+	    				if (remainingWork_kWh == 0 || DoubleCompare.lessThanZero(remainingWork_kWh)) {
+	    					break;
+	    				}
+	    			}
+	    		}
+	    		currentSOC_kWh += initialWork_kWh - remainingWork_kWh;
+	    	}
+			for (int i = 0; i < timeStepsInForecast; i++) {
+				electricityLoad_kW[i] += EVLoad_kW[i];
+			}
+		}
+		
+		OL_ForecastStatus status = OL_ForecastStatus.ESTIMATED_FORECAST;
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		loadMap.put(OL_EnergyCarriers.ELECTRICITY, electricityLoad_kW);
+		String reason = "Forecast is not perfect as EV starting SOC is guessed. If forecast starttime is the current modeltime forecast is perfect.";
+		return new J_AssetTypeForecast(I_ChargingManagement.class, loadMap, status, reason);
+	}
     
 	public void setV2GActive(boolean activateV2G) {
 		if(activateV2G) {

--- a/_alp/Classes/Class.J_ChargingManagementSimple.java
+++ b/_alp/Classes/Class.J_ChargingManagementSimple.java
@@ -64,24 +64,24 @@ public class J_ChargingManagementSimple implements I_ChargingManagement {
 	    	double[] EVLoad_kW = new double[timeStepsInForecast];
 			J_ActivityTrackerTrips tripTracker = ev.getTripTracker();
 			List<TripRecord> trips = tripTracker.getTripsInRange(timeOfIntervalStart_h, timeOfIntervalEnd_h);
-	    	
+
 			double maximalStorageCapacity_kWh = ev.getStorageCapacity_kWh();
 			double currentSOC_kWh = ev.getCurrentSOC_kWh(); // Assumes the SOC of the EV at start of forecast is current SOC
 		    double work_kWh = maximalStorageCapacity_kWh - currentSOC_kWh;
-	    	double endTimeLastTrip_h = ev.getAvailability() ? 0.0 : tripTracker.getCurrentTripEndTime_h()%24; // Assumes the current trip ends today, i.e. no trips > 24 hours exist)
+	    	double endTimeLastTrip_h = ev.getAvailability() ? timeOfIntervalStart_h : tripTracker.getCurrentTripEndTime_h()%24; // Assumes the current trip ends today, i.e. no trips > 24 hours exist)
     		double firstAvailableChargingTime_h = this.timeParameters.getTimeStep_h() * Math.ceil(endTimeLastTrip_h / this.timeParameters.getTimeStep_h());
     		double startTimeNextTrip_h = trips.size() > 0 ? trips.get(0).startTime_h() : timeOfIntervalEnd_h;
     		double lastAvailableChargingTime_h = this.timeParameters.getTimeStep_h() * Math.floor(startTimeNextTrip_h / this.timeParameters.getTimeStep_h());
     		double maxPower_kW = ev.getVehicleChargingCapacity_kW();
-    		double maxWork_kWh = (lastAvailableChargingTime_h - firstAvailableChargingTime_h) * maxPower_kW;
+    		double maxWork_kWh = (lastAvailableChargingTime_h - firstAvailableChargingTime_h + this.timeParameters.getTimeStep_h()) * maxPower_kW;
     		double initialWork_kWh = max(0, min(work_kWh, maxWork_kWh));
     		double remainingWork_kWh = initialWork_kWh;
     		for (int i = 0; i < timeStepsInForecast; i++) {
-    			double t = i*this.timeParameters.getTimeStep_h();
-    			if (t >= firstAvailableChargingTime_h && t <= lastAvailableChargingTime_h) {  // >= or > ?
+    			double t = timeOfIntervalStart_h + i*this.timeParameters.getTimeStep_h();
+    			if (t >= firstAvailableChargingTime_h && t <= lastAvailableChargingTime_h) {
     				EVLoad_kW[i] = max(0, min(maxPower_kW, remainingWork_kWh / this.timeParameters.getTimeStep_h()));
     				remainingWork_kWh -= EVLoad_kW[i] * this.timeParameters.getTimeStep_h();
-    				if (remainingWork_kWh == 0 || DoubleCompare.lessThanZero(remainingWork_kWh)) {
+    				if (DoubleCompare.equalsZero(remainingWork_kWh) || DoubleCompare.lessThanZero(remainingWork_kWh)) {
     					break;
     				}
     			}
@@ -92,20 +92,21 @@ public class J_ChargingManagementSimple implements I_ChargingManagement {
 	    		TripRecord trip = trips.get(tripIndex);
 	    		double distance_km = trip.distance_km();
 	    		currentSOC_kWh -= distance_km * ev.getEnergyConsumption_kWhpkm();
-	    		work_kWh = maximalStorageCapacity_kWh - currentSOC_kWh;    		
+				work_kWh = maximalStorageCapacity_kWh - currentSOC_kWh;    		
 	    		endTimeLastTrip_h = trip.endTime_h();
 	    		firstAvailableChargingTime_h = this.timeParameters.getTimeStep_h() * Math.ceil(endTimeLastTrip_h / this.timeParameters.getTimeStep_h());
 	    		startTimeNextTrip_h = (tripIndex == trips.size() - 1) ? timeOfIntervalEnd_h : trips.get(tripIndex+1).startTime_h();
 	    		lastAvailableChargingTime_h = this.timeParameters.getTimeStep_h() * Math.floor(startTimeNextTrip_h / this.timeParameters.getTimeStep_h());
-	    		maxWork_kWh = (lastAvailableChargingTime_h - firstAvailableChargingTime_h) * maxPower_kW;
+	    		maxWork_kWh = (lastAvailableChargingTime_h - firstAvailableChargingTime_h + this.timeParameters.getTimeStep_h()) * maxPower_kW;
 	    		initialWork_kWh = max(0, min(work_kWh, maxWork_kWh));
 	    		remainingWork_kWh = initialWork_kWh;
 	    		for (int i = 0; i < timeStepsInForecast; i++) {
-	    			double t = i*this.timeParameters.getTimeStep_h();
-	    			if (t >= firstAvailableChargingTime_h && t <= lastAvailableChargingTime_h) {  // >= or > ?
+	    			double t = timeOfIntervalStart_h + i*this.timeParameters.getTimeStep_h();
+	    			if (t >= firstAvailableChargingTime_h && t <= lastAvailableChargingTime_h) {
 	    				EVLoad_kW[i] = max(0, min(maxPower_kW, remainingWork_kWh / this.timeParameters.getTimeStep_h()));
+	    				double x = max(0, min(maxPower_kW, remainingWork_kWh / this.timeParameters.getTimeStep_h()));
 	    				remainingWork_kWh -= EVLoad_kW[i] * this.timeParameters.getTimeStep_h();
-	    				if (remainingWork_kWh == 0 || DoubleCompare.lessThanZero(remainingWork_kWh)) {
+	    				if (DoubleCompare.equalsZero(remainingWork_kWh) || DoubleCompare.lessThanZero(remainingWork_kWh)) {
 	    					break;
 	    				}
 	    			}
@@ -134,7 +135,6 @@ public class J_ChargingManagementSimple implements I_ChargingManagement {
 		return this.V2GActive;
 	}
 	
-	
     //Get parentagent
     public Agent getParentAgent() {
     	return this.gc;
@@ -148,10 +148,8 @@ public class J_ChargingManagementSimple implements I_ChargingManagement {
 		
 	}
 	
-	
     @Override
 	public String toString() {
 		return "Active charging type: " + this.activeChargingType;
-
 	}
 }

--- a/_alp/Classes/Class.J_CurtailManagementContractCapacity.java
+++ b/_alp/Classes/Class.J_CurtailManagementContractCapacity.java
@@ -45,6 +45,13 @@ public class J_CurtailManagementContractCapacity implements I_CurtailManagement 
 		}
 	}
 	
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_CurtailManagement.class, loadMap, status, reason);
+	}
+	
     ////Store and reset states
 	public void storeStatesAndReset() {
 		//Nothing to store and reset

--- a/_alp/Classes/Class.J_CurtailManagementExternalSetpoint.java
+++ b/_alp/Classes/Class.J_CurtailManagementExternalSetpoint.java
@@ -53,6 +53,13 @@ public class J_CurtailManagementExternalSetpoint implements I_CurtailManagement 
 		curtailmentSetpoint_kW = 0;
 	}
 	
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "External Setpoint Management can not be forecasted.";
+		return new J_AssetTypeForecast(I_CurtailManagement.class, loadMap, status, reason);
+	}
+
 	public void setCurtailmentSetpoint(double curtailmentSetpoint_kW) {
 		this.curtailmentSetpoint_kW = curtailmentSetpoint_kW;
 	}

--- a/_alp/Classes/Class.J_CurtailManagementPrice.java
+++ b/_alp/Classes/Class.J_CurtailManagementPrice.java
@@ -46,6 +46,13 @@ public class J_CurtailManagementPrice implements I_CurtailManagement {
 		}
 	}
 	
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_CurtailManagement.class, loadMap, status, reason);
+	}
+	
     ////Store and reset states
 	public void storeStatesAndReset() {
 		//Nothing to store and reset

--- a/_alp/Classes/Class.J_EAConversionHeatPump.java
+++ b/_alp/Classes/Class.J_EAConversionHeatPump.java
@@ -131,7 +131,7 @@ public class J_EAConversionHeatPump extends zero_engine.J_EAConversion implement
 	
 	public double calculateCOP(double outputTemperature_degC, double baseTemperature_degC) {
 		//double COP_r = this.eta_r * ( 273.15 + this.outputTemperature_degC ) / ( this.outputTemperature_degC - this.baseTemperature_degC );
-		double deltaT = max(1,this.outputTemperature_degC - this.baseTemperature_degC); // Limit deltaT to at least 1 degree.
+		double deltaT = max(1, outputTemperature_degC - baseTemperature_degC); // Limit deltaT to at least 1 degree.
 	    double COP_r = 8.74 - 0.190 * deltaT + 0.00126 * deltaT*deltaT;
 	    return COP_r;
 	}

--- a/_alp/Classes/Class.J_ElectrolyserManagementPowerSurplus.java
+++ b/_alp/Classes/Class.J_ElectrolyserManagementPowerSurplus.java
@@ -193,6 +193,13 @@ public class J_ElectrolyserManagementPowerSurplus implements I_ElectrolyserManag
     	}
     }
     
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_ElectrolyserManagement.class, loadMap, status, reason);
+	}
+	
     public void setTarget(Agent target) {
     	this.target = target;
     }

--- a/_alp/Classes/Class.J_ElectrolyserManagementPrice.java
+++ b/_alp/Classes/Class.J_ElectrolyserManagementPrice.java
@@ -141,6 +141,13 @@ public class J_ElectrolyserManagementPrice implements I_ElectrolyserManagement {
 	    }
     }
     
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_ElectrolyserManagement.class, loadMap, status, reason);
+	}
+    
     public void setElectricityPriceMaxForProfit_eurpkWh(double electricityPriceMaxForProfit_eurpkWh) {
     	this.electricityPriceMaxForProfit_eurpkWh = electricityPriceMaxForProfit_eurpkWh;
     }

--- a/_alp/Classes/Class.J_FlexProfileManagementDefault.java
+++ b/_alp/Classes/Class.J_FlexProfileManagementDefault.java
@@ -22,6 +22,26 @@ public class J_FlexProfileManagementDefault implements I_FlexProfileManagement{
     	gc.c_flexProfileAssets.forEach(flexProfile -> gc.f_updateFlexAssetFlows(flexProfile, 1.0, timeVariables));
     }
     
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		int timeStepsInForecast = roundToInt((timeOfIntervalEnd_h - timeOfIntervalStart_h) / this.timeParameters.getTimeStep_h());
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		for (J_EAFlexProfile flexProfile : gc.c_flexProfileAssets) {
+			OL_EnergyCarriers EC = flexProfile.getEnergyCarrier();
+			if (loadMap.get(EC) == null) {
+				Double[] loadProfile_kW = new Double[timeStepsInForecast];
+				Arrays.fill(loadProfile_kW, 0.0);
+				loadMap.put(EC, loadProfile_kW);
+			}
+			J_ProfilePointer pp = flexProfile.getProfilePointer();
+			for (int i = 0; i < timeStepsInForecast; i++) {
+				double t = timeOfIntervalStart_h + i * this.timeParameters.getTimeStep_h();
+				loadMap.get(EC)[i] += pp.getValue(t);
+			}
+		}
+		OL_ForecastStatus status = OL_ForecastStatus.PERFECT_FORECAST;
+		return new J_AssetTypeForecast(I_FlexProfileManagement.class, loadMap, status, null);
+	}
+	
     ////Store and reset states
 	public void storeStatesAndReset() {
 		//Nothing to store and reset

--- a/_alp/Classes/Class.J_FlexProfileManagementHeatprofileHeatpump.java
+++ b/_alp/Classes/Class.J_FlexProfileManagementHeatprofileHeatpump.java
@@ -141,6 +141,13 @@ public class J_FlexProfileManagementHeatprofileHeatpump implements I_FlexProfile
 		this.flexProfileSetpointArray_fr = newFlexProfileSetpointArray;
     }
     
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_FlexProfileManagement.class, loadMap, status, reason);
+	}
+	
     //Setters
     public void setMaxFlexProfileShift_fr(double maxFlexProfileShift_fr) {
     	if(maxFlexProfileShift_fr<0) {

--- a/_alp/Classes/Class.J_HeatingManagementCHP.java
+++ b/_alp/Classes/Class.J_HeatingManagementCHP.java
@@ -95,7 +95,12 @@ public class J_HeatingManagementCHP implements I_HeatingManagement {
     	return this.heatingPreferences;
     }
     
-    
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);
+	}
     
     //Get parentagent
     public Agent getParentAgent() {

--- a/_alp/Classes/Class.J_HeatingManagementDistrictHeating.java
+++ b/_alp/Classes/Class.J_HeatingManagementDistrictHeating.java
@@ -120,7 +120,13 @@ public class J_HeatingManagementDistrictHeating implements I_HeatingManagement {
     	return this.heatingPreferences;
     }
     
-    
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);
+	}
+	
     //Get parentagent
     public Agent getParentAgent() {
     	return this.gc;

--- a/_alp/Classes/Class.J_HeatingManagementGhost.java
+++ b/_alp/Classes/Class.J_HeatingManagementGhost.java
@@ -72,8 +72,12 @@ public class J_HeatingManagementGhost implements I_HeatingManagement {
     	return this.heatingPreferences;
     }
     
-    
-    
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);
+	}    
     
     //Get parentagent
     public Agent getParentAgent() {

--- a/_alp/Classes/Class.J_HeatingManagementHeatpumpOffPeak.java
+++ b/_alp/Classes/Class.J_HeatingManagementHeatpumpOffPeak.java
@@ -351,7 +351,12 @@ public class J_HeatingManagementHeatpumpOffPeak implements I_HeatingManagement {
     	return this.heatingPreferences;
     }
 
-    
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);
+	}
     
     //Get parentagent
     public Agent getParentAgent() {

--- a/_alp/Classes/Class.J_HeatingManagementNeighborhood.java
+++ b/_alp/Classes/Class.J_HeatingManagementNeighborhood.java
@@ -322,7 +322,13 @@ public class J_HeatingManagementNeighborhood implements I_HeatingManagement {
     	return heatDemandProfiles.get(name);
     }
     
-    
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);
+	}
+	
     //Get parentagent
     public Agent getParentAgent() {
     	return this.gc;

--- a/_alp/Classes/Class.J_HeatingManagementPIcontrol.java
+++ b/_alp/Classes/Class.J_HeatingManagementPIcontrol.java
@@ -259,8 +259,10 @@ public class J_HeatingManagementPIcontrol implements I_HeatingManagement {
 		case ELECTRIC_HEATPUMP:
 			EC = OL_EnergyCarriers.ELECTRICITY;
 			break;
-		case DISTRICTHEAT:			
-			return new J_AssetTypeForecast(J_HeatingManagementPIcontrol.class, loadMap, OL_ForecastStatus.PERFECT_FORECAST, "GC connected to districtheating, so load is zero.");
+		case DISTRICTHEAT:	
+			Double[] heatLoad = Arrays.stream(buildingHeatDemand_kW).boxed().toArray(Double[]::new);
+			loadMap.put(OL_EnergyCarriers.HEAT, heatLoad);
+			return new J_AssetTypeForecast(J_HeatingManagementPIcontrol.class, loadMap, OL_ForecastStatus.ESTIMATED_FORECAST, "GC connected to districtheating, so all heat demand is import. Building forecast simplified by omitting solar radiation & ventilation.");
 		default:
 			throw new RuntimeException(String.format("Tried to forecast J_HeatingManagementPIControl, but encountered an unexepected heating type %s in GC %s", this.gc.f_getCurrentHeatingType(), this.gc.p_gridConnectionID));
 		}
@@ -285,9 +287,9 @@ public class J_HeatingManagementPIcontrol implements I_HeatingManagement {
 			hp = ((J_EAConversionHeatPump)this.heatingAsset);
 			for (int i = 0; i < timeStepsInForecast; i++) {
 				double t = timeOfIntervalStart_h + i * timeParameters.getTimeStep_h();
-				double totalHeatDemand_kW = buildingHeatDemand_kW[i] + otherFixedHeatDemand_kW[i];
+				double heatDemand_kW = buildingHeatDemand_kW[i] + otherFixedHeatDemand_kW[i];
 				double efficiency_fr = hp.calculateCOP(hp.getOutputTemperature_degC(), ambientTemperatureProfile.getValue(t));
-				double load_kW = totalHeatDemand_kW / efficiency_fr;
+				double load_kW = heatDemand_kW / efficiency_fr;
 				loadProfile_kW[i] = load_kW;
 			}
 			break;
@@ -296,12 +298,15 @@ public class J_HeatingManagementPIcontrol implements I_HeatingManagement {
 		if (fixedEfficiency) {
 			for (int i = 0; i < timeStepsInForecast; i++) {
 				double t = timeOfIntervalStart_h + i * timeParameters.getTimeStep_h();
-				double totalHeatDemand_kW = buildingHeatDemand_kW[i] + otherFixedHeatDemand_kW[i];
-				double load_kW = totalHeatDemand_kW / fixedEfficiency_fr;
+				double heatDemand_kW = buildingHeatDemand_kW[i] + otherFixedHeatDemand_kW[i];
+				double load_kW = heatDemand_kW / fixedEfficiency_fr;
 				loadProfile_kW[i] = load_kW;
 			}
 		}
 		loadMap.put(EC, loadProfile_kW);
+		// Building is a flex asset so its heat demand is included in system bounds of heating management, but fixed profiles are not.
+		Double[] heatLoad = Arrays.stream(otherFixedHeatDemand_kW).map(d -> -d).boxed().toArray(Double[]::new);
+		loadMap.put(OL_EnergyCarriers.HEAT, heatLoad);
 		OL_ForecastStatus status = OL_ForecastStatus.ESTIMATED_FORECAST;
 		String reason = "PI & Building states based on current timestep. Building forecast simplified by omitting solar radiation & ventilation.";
 		return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);

--- a/_alp/Classes/Class.J_HeatingManagementPIcontrol.java
+++ b/_alp/Classes/Class.J_HeatingManagementPIcontrol.java
@@ -237,6 +237,13 @@ public class J_HeatingManagementPIcontrol implements I_HeatingManagement {
     	return this.heatingPreferences;
     }
     
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);
+	}
+	
     //Get parentagent
     public Agent getParentAgent() {
     	return this.gc;

--- a/_alp/Classes/Class.J_HeatingManagementPIcontrol.java
+++ b/_alp/Classes/Class.J_HeatingManagementPIcontrol.java
@@ -239,10 +239,125 @@ public class J_HeatingManagementPIcontrol implements I_HeatingManagement {
     
 	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
 		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
-		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
-		String reason = "Not yet implemented.";
+		int timeStepsInForecast = roundToInt((timeOfIntervalEnd_h - timeOfIntervalStart_h) / this.timeParameters.getTimeStep_h());
+		Double[] loadProfile_kW = new Double[timeStepsInForecast];
+		J_ProfilePointer ambientTemperatureProfile = this.gc.energyModel.pp_ambientTemperature_degC;
+		J_ProfileForecaster ambientTempeartureForecast = this.gc.energyModel.pf_ambientTemperature_degC;
+		double[] buildingHeatDemand_kW = this.getBuildingHeatDemandProfile(timeOfIntervalStart_h, timeStepsInForecast, ambientTemperatureProfile, ambientTempeartureForecast);
+		double[] otherFixedHeatDemand_kW = this.gc.f_getFixedAssetForecast(timeOfIntervalStart_h, timeOfIntervalEnd_h, OL_EnergyCarriers.HEAT, this.timeParameters);
+		
+		// We switch over the heating type twice, first to set the EnergyCarrier
+		OL_EnergyCarriers EC;
+		switch (this.gc.f_getCurrentHeatingType()) {
+		case GAS_BURNER:
+			EC = OL_EnergyCarriers.METHANE;
+			break;
+		case HYDROGENBURNER:
+			EC = OL_EnergyCarriers.HYDROGEN;
+			break;
+		case LT_DISTRICTHEAT:
+		case ELECTRIC_HEATPUMP:
+			EC = OL_EnergyCarriers.ELECTRICITY;
+			break;
+		case DISTRICTHEAT:			
+			return new J_AssetTypeForecast(J_HeatingManagementPIcontrol.class, loadMap, OL_ForecastStatus.PERFECT_FORECAST, "GC connected to districtheating, so load is zero.");
+		default:
+			throw new RuntimeException(String.format("Tried to forecast J_HeatingManagementPIControl, but encountered an unexepected heating type %s in GC %s", this.gc.f_getCurrentHeatingType(), this.gc.p_gridConnectionID));
+		}
+		
+		// Then to determine the profile.
+		// Here we make a distinction between fixed efficiency, and efficiency variable per timestep.
+		boolean fixedEfficiency = false;
+		double fixedEfficiency_fr = 1.0;
+		J_EAConversionHeatPump hp = null;
+		switch (this.gc.f_getCurrentHeatingType()) {
+		case LT_DISTRICTHEAT:
+			fixedEfficiency = true;
+			hp = ((J_EAConversionHeatPump)this.heatingAsset);
+			fixedEfficiency_fr = hp.getCOP();
+			break;
+		case GAS_BURNER:
+		case HYDROGENBURNER:
+			fixedEfficiency = true;
+			fixedEfficiency_fr = this.heatingAsset.getEta_r();
+			break;
+		case ELECTRIC_HEATPUMP:
+			hp = ((J_EAConversionHeatPump)this.heatingAsset);
+			for (int i = 0; i < timeStepsInForecast; i++) {
+				double t = timeOfIntervalStart_h + i * timeParameters.getTimeStep_h();
+				double totalHeatDemand_kW = buildingHeatDemand_kW[i] + otherFixedHeatDemand_kW[i];
+				double efficiency_fr = hp.calculateCOP(hp.getOutputTemperature_degC(), ambientTemperatureProfile.getValue(t));
+				double load_kW = totalHeatDemand_kW / efficiency_fr;
+				loadProfile_kW[i] = load_kW;
+			}
+			break;
+		}
+		
+		if (fixedEfficiency) {
+			for (int i = 0; i < timeStepsInForecast; i++) {
+				double t = timeOfIntervalStart_h + i * timeParameters.getTimeStep_h();
+				double totalHeatDemand_kW = buildingHeatDemand_kW[i] + otherFixedHeatDemand_kW[i];
+				double load_kW = totalHeatDemand_kW / fixedEfficiency_fr;
+				loadProfile_kW[i] = load_kW;
+			}
+		}
+		loadMap.put(EC, loadProfile_kW);
+		OL_ForecastStatus status = OL_ForecastStatus.ESTIMATED_FORECAST;
+		String reason = "PI & Building states based on current timestep. Building forecast simplified by omitting solar radiation & ventilation.";
 		return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);
 	}
+	
+	private double[] getBuildingHeatDemandProfile(double timeAtStartForecast_h, int timeStepsInForecast, J_ProfilePointer ambientTemperatureProfile, J_ProfileForecaster ambientTempeartureForecast) {
+        double[] buildingHeatDemandProfile_kW = new double[timeStepsInForecast];
+
+        double dayStartTime_h = this.heatingPreferences.getStartOfDayTime_h();
+        double nightStartTime_h = this.heatingPreferences.getStartOfNightTime_h();
+        double daySetpoint_degC = this.heatingPreferences.getDayTimeSetPoint_degC();
+        double nightSetpoint_degC = this.heatingPreferences.getNightTimeSetPoint_degC();
+        double avgTemp24h_degC = ambientTempeartureForecast.getForecast(); // Assumes timeAtStartForecast_h is current model time and forecasting horizon is 24h.
+
+        double simBuildingTemp_degC = this.building.getCurrentTemperature();
+        double simFilteredSetpoint_degC = this.filteredCurrentSetpoint_degC;
+        double simIState_hDegC = this.I_state_hDegC;
+
+        double pGain_kWpDegC = this.P_gain_kWpDegC;
+        double iGain_kWphDegC = this.I_gain_kWphDegC;
+        double filterTimeScale_h = this.setpointFilterTimeScale_h;
+        double timeStep_h = this.timeParameters.getTimeStep_h();
+
+        double lossFactor_WpK = this.building.getLossFactor_WpK();
+        double lossScalingFactor_fr = this.building.getLossScalingFactor_fr();
+        double heatCapacity_kWhpK = this.building.getHeatCapacity_JpK() / 3.6e6;
+
+        for (int i = 0; i < timeStepsInForecast; i++) {
+            double t = timeAtStartForecast_h + i * timeStep_h;
+            double timeOfDay_h = t % 24.0;
+            double ambientTemp_degC = ambientTemperatureProfile.getValue(t);
+
+            // Same setpoint-selection logic as manageHeating, incl. the heating-season hysteresis
+            double currentSetpoint_degC = daySetpoint_degC;
+            if (avgTemp24h_degC > J_HeatingFunctionLibrary.heatingDaysAvgTempTreshold_degC) {
+                currentSetpoint_degC = nightSetpoint_degC;
+            } else if (timeOfDay_h < dayStartTime_h || timeOfDay_h >= nightStartTime_h) {
+                currentSetpoint_degC = nightSetpoint_degC;
+            }
+
+            // Same order of operations as manageHeating: filter first, then deltaT vs *previous* building temp
+            simFilteredSetpoint_degC += (timeStep_h / filterTimeScale_h) * (currentSetpoint_degC - simFilteredSetpoint_degC);
+            double deltaT_degC = simFilteredSetpoint_degC - simBuildingTemp_degC;
+            simIState_hDegC = max(0, simIState_hDegC + deltaT_degC * timeStep_h);
+            double heatingDemand_kW = max(0, deltaT_degC * pGain_kWpDegC + simIState_hDegC * iGain_kWphDegC);
+
+            buildingHeatDemandProfile_kW[i] = heatingDemand_kW;
+
+            // Advance building temperature under this heat input for the next step
+            double heatLoss_kW = (lossFactor_WpK * (simBuildingTemp_degC - ambientTemp_degC) / 1000) * lossScalingFactor_fr;
+            double netHeat_kW = heatingDemand_kW - heatLoss_kW;
+            simBuildingTemp_degC += (netHeat_kW / heatCapacity_kWhpK) * timeStep_h;
+        }
+
+        return buildingHeatDemandProfile_kW;
+    }
 	
     //Get parentagent
     public Agent getParentAgent() {

--- a/_alp/Classes/Class.J_HeatingManagementPIcontrolHybridHeatpump.java
+++ b/_alp/Classes/Class.J_HeatingManagementPIcontrolHybridHeatpump.java
@@ -253,7 +253,7 @@ public class J_HeatingManagementPIcontrolHybridHeatpump implements I_HeatingMana
 			double COP_fr = this.heatPumpAsset.calculateCOP(this.heatPumpAsset.getOutputTemperature_degC(), ambientTemperatureProfile.getValue(t));
 			if (COP_fr < 3.0) {
 				gasLoadProfile_kW[i] = min(gasBurnerMaxOutput_kW, totalHeatDemand_kW / gasBurnerEfficiency_fr);
-				electricityLoadProfile_kW[i] = max(0, (totalHeatDemand_kW - gasBurnerMaxOutput_kW * gasBurnerEfficiency_fr) / COP_fr);
+				electricityLoadProfile_kW[i] = max(0, (totalHeatDemand_kW - gasBurnerMaxOutput_kW) / COP_fr);
 			}
 			else {
 				electricityLoadProfile_kW[i] = min(heatpumpInputCapacity_kW, totalHeatDemand_kW / COP_fr);
@@ -262,6 +262,9 @@ public class J_HeatingManagementPIcontrolHybridHeatpump implements I_HeatingMana
 		}
 		loadMap.put(OL_EnergyCarriers.ELECTRICITY, electricityLoadProfile_kW);
 		loadMap.put(OL_EnergyCarriers.METHANE, gasLoadProfile_kW);
+		// Building is a flex asset so included in system bounds of heating management, but fixed profiles are not.
+		Double[] heatLoad = Arrays.stream(otherFixedHeatDemand_kW).map(d -> -d).boxed().toArray(Double[]::new);
+		loadMap.put(OL_EnergyCarriers.HEAT, heatLoad);
 		OL_ForecastStatus status = OL_ForecastStatus.ESTIMATED_FORECAST;
 		String reason = "PI & Building states based on current timestep. Building forecast simplified by omitting solar radiation & ventilation.";
 		return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);

--- a/_alp/Classes/Class.J_HeatingManagementPIcontrolHybridHeatpump.java
+++ b/_alp/Classes/Class.J_HeatingManagementPIcontrolHybridHeatpump.java
@@ -212,13 +212,6 @@ public class J_HeatingManagementPIcontrolHybridHeatpump implements I_HeatingMana
 		this.filteredCurrentSetpoint_degC = heatingPreferences.getMinComfortTemperature_degC();
     	this.isInitialized = true;
     }
-    
-	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
-		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
-		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
-		String reason = "Not yet implemented.";
-		return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);
-	}
 	
     public void notInitialized() {
     	this.isInitialized = false;
@@ -238,6 +231,92 @@ public class J_HeatingManagementPIcontrolHybridHeatpump implements I_HeatingMana
     
     public J_HeatingPreferences getHeatingPreferences() {
     	return this.heatingPreferences;
+    }
+    
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		int timeStepsInForecast = roundToInt((timeOfIntervalEnd_h - timeOfIntervalStart_h) / this.timeParameters.getTimeStep_h());
+		Double[] electricityLoadProfile_kW = new Double[timeStepsInForecast];
+		Double[] gasLoadProfile_kW = new Double[timeStepsInForecast];
+		J_ProfilePointer ambientTemperatureProfile = this.gc.energyModel.pp_ambientTemperature_degC;
+		J_ProfileForecaster ambientTempeartureForecast = this.gc.energyModel.pf_ambientTemperature_degC;
+		double[] buildingHeatDemand_kW = this.getBuildingHeatDemandProfile(timeOfIntervalStart_h, timeStepsInForecast, ambientTemperatureProfile, ambientTempeartureForecast);
+		double[] otherFixedHeatDemand_kW = this.gc.f_getFixedAssetForecast(timeOfIntervalStart_h, timeOfIntervalEnd_h, OL_EnergyCarriers.HEAT, this.timeParameters);
+		
+		double gasBurnerEfficiency_fr = this.gasBurnerAsset.getEta_r();
+		double gasBurnerMaxOutput_kW = this.gasBurnerAsset.getOutputCapacity_kW();
+		double heatpumpInputCapacity_kW = this.heatPumpAsset.getInputCapacity_kW();
+		
+		for (int i = 0; i < timeStepsInForecast; i++) {
+			double t = timeOfIntervalStart_h + i * timeParameters.getTimeStep_h();
+			double totalHeatDemand_kW = buildingHeatDemand_kW[i] + otherFixedHeatDemand_kW[i];
+			double COP_fr = this.heatPumpAsset.calculateCOP(this.heatPumpAsset.getOutputTemperature_degC(), ambientTemperatureProfile.getValue(t));
+			if (COP_fr < 3.0) {
+				gasLoadProfile_kW[i] = min(gasBurnerMaxOutput_kW, totalHeatDemand_kW / gasBurnerEfficiency_fr);
+				electricityLoadProfile_kW[i] = max(0, (totalHeatDemand_kW - gasBurnerMaxOutput_kW * gasBurnerEfficiency_fr) / COP_fr);
+			}
+			else {
+				electricityLoadProfile_kW[i] = min(heatpumpInputCapacity_kW, totalHeatDemand_kW / COP_fr);
+				gasLoadProfile_kW[i] = max(0, (totalHeatDemand_kW - heatpumpInputCapacity_kW * COP_fr) / gasBurnerEfficiency_fr);
+			}
+		}
+		loadMap.put(OL_EnergyCarriers.ELECTRICITY, electricityLoadProfile_kW);
+		loadMap.put(OL_EnergyCarriers.METHANE, gasLoadProfile_kW);
+		OL_ForecastStatus status = OL_ForecastStatus.ESTIMATED_FORECAST;
+		String reason = "PI & Building states based on current timestep. Building forecast simplified by omitting solar radiation & ventilation.";
+		return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);
+	}
+	
+	private double[] getBuildingHeatDemandProfile(double timeAtStartForecast_h, int timeStepsInForecast, J_ProfilePointer ambientTemperatureProfile, J_ProfileForecaster ambientTempeartureForecast) {
+        double[] buildingHeatDemandProfile_kW = new double[timeStepsInForecast];
+
+        double dayStartTime_h = this.heatingPreferences.getStartOfDayTime_h();
+        double nightStartTime_h = this.heatingPreferences.getStartOfNightTime_h();
+        double daySetpoint_degC = this.heatingPreferences.getDayTimeSetPoint_degC();
+        double nightSetpoint_degC = this.heatingPreferences.getNightTimeSetPoint_degC();
+        double avgTemp24h_degC = ambientTempeartureForecast.getForecast();  // Assumes timeAtStartForecast_h is current model time and forecasting horizon is 24h.
+
+        double simBuildingTemp_degC = this.building.getCurrentTemperature();
+        double simFilteredSetpoint_degC = this.filteredCurrentSetpoint_degC;
+        double simIState_hDegC = this.I_state_hDegC;
+
+        double pGain_kWpDegC = this.P_gain_kWpDegC;
+        double iGain_kWphDegC = this.I_gain_kWphDegC;
+        double filterTimeScale_h = this.setpointFilterTimeScale_h;
+        double timeStep_h = this.timeParameters.getTimeStep_h();
+
+        double lossFactor_WpK = this.building.getLossFactor_WpK();
+        double lossScalingFactor_fr = this.building.getLossScalingFactor_fr();
+        double heatCapacity_kWhpK = this.building.getHeatCapacity_JpK() / 3.6e6;
+
+        for (int i = 0; i < timeStepsInForecast; i++) {
+            double t = timeAtStartForecast_h + i * timeStep_h;
+            double timeOfDay_h = t % 24.0;
+            double ambientTemp_degC = ambientTemperatureProfile.getValue(t);
+
+            // Same setpoint-selection logic as manageHeating, incl. the heating-season hysteresis
+            double currentSetpoint_degC = daySetpoint_degC;
+            if (avgTemp24h_degC > J_HeatingFunctionLibrary.heatingDaysAvgTempTreshold_degC) {
+                currentSetpoint_degC = nightSetpoint_degC;
+            } else if (timeOfDay_h < dayStartTime_h || timeOfDay_h >= nightStartTime_h) {
+                currentSetpoint_degC = nightSetpoint_degC;
+            }
+
+            // Same order of operations as manageHeating: filter first, then deltaT vs *previous* building temp
+            simFilteredSetpoint_degC += (timeStep_h / filterTimeScale_h) * (currentSetpoint_degC - simFilteredSetpoint_degC);
+            double deltaT_degC = simFilteredSetpoint_degC - simBuildingTemp_degC;
+            simIState_hDegC = max(0, simIState_hDegC + deltaT_degC * timeStep_h);
+            double heatingDemand_kW = max(0, deltaT_degC * pGain_kWpDegC + simIState_hDegC * iGain_kWphDegC);
+
+            buildingHeatDemandProfile_kW[i] = heatingDemand_kW;
+
+            // Advance building temperature under this heat input for the next step
+            double heatLoss_kW = (lossFactor_WpK * (simBuildingTemp_degC - ambientTemp_degC) / 1000) * lossScalingFactor_fr;
+            double netHeat_kW = heatingDemand_kW - heatLoss_kW;
+            simBuildingTemp_degC += (netHeat_kW / heatCapacity_kWhpK) * timeStep_h;
+        }
+
+        return buildingHeatDemandProfile_kW;
     }
     
 	//Get parentagent

--- a/_alp/Classes/Class.J_HeatingManagementPIcontrolHybridHeatpump.java
+++ b/_alp/Classes/Class.J_HeatingManagementPIcontrolHybridHeatpump.java
@@ -213,7 +213,13 @@ public class J_HeatingManagementPIcontrolHybridHeatpump implements I_HeatingMana
     	this.isInitialized = true;
     }
     
-    
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);
+	}
+	
     public void notInitialized() {
     	this.isInitialized = false;
     }

--- a/_alp/Classes/Class.J_HeatingManagementProfileHybridHeatPump.java
+++ b/_alp/Classes/Class.J_HeatingManagementProfileHybridHeatPump.java
@@ -136,8 +136,34 @@ public class J_HeatingManagementProfileHybridHeatPump implements I_HeatingManage
     
 	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
 		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
-		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
-		String reason = "Not yet implemented.";
+		int timeStepsInForecast = roundToInt((timeOfIntervalEnd_h - timeOfIntervalStart_h) / this.timeParameters.getTimeStep_h());
+		Double[] electricityLoadProfile_kW = new Double[timeStepsInForecast];
+		Double[] gasLoadProfile_kW = new Double[timeStepsInForecast];
+		J_ProfilePointer ambientTemperatureProfile = this.gc.energyModel.pp_ambientTemperature_degC;
+		double[] fixedHeatDemand_kW = this.gc.f_getFixedAssetForecast(timeOfIntervalStart_h, timeOfIntervalEnd_h, OL_EnergyCarriers.HEAT, this.timeParameters);
+		
+		double gasBurnerEfficiency_fr = this.gasBurnerAsset.getEta_r();
+		double gasBurnerMaxOutput_kW = this.gasBurnerAsset.getOutputCapacity_kW();
+		double heatpumpInputCapacity_kW = this.heatPumpAsset.getInputCapacity_kW();
+		
+		for (int i = 0; i < timeStepsInForecast; i++) {
+			double t = timeOfIntervalStart_h + i * timeParameters.getTimeStep_h();
+			double totalHeatDemand_kW = fixedHeatDemand_kW[i];
+			double COP_fr = this.heatPumpAsset.calculateCOP(this.heatPumpAsset.getOutputTemperature_degC(), ambientTemperatureProfile.getValue(t));
+			if (COP_fr < 3.0) {
+				gasLoadProfile_kW[i] = min(gasBurnerMaxOutput_kW, totalHeatDemand_kW / gasBurnerEfficiency_fr);
+				electricityLoadProfile_kW[i] = max(0, (totalHeatDemand_kW - gasBurnerMaxOutput_kW * gasBurnerEfficiency_fr) / COP_fr);
+			}
+			else {
+				electricityLoadProfile_kW[i] = min(heatpumpInputCapacity_kW, totalHeatDemand_kW / COP_fr);
+				gasLoadProfile_kW[i] = max(0, (totalHeatDemand_kW - heatpumpInputCapacity_kW * COP_fr) / gasBurnerEfficiency_fr);
+			}
+		}
+		loadMap.put(OL_EnergyCarriers.ELECTRICITY, electricityLoadProfile_kW);
+		loadMap.put(OL_EnergyCarriers.METHANE, gasLoadProfile_kW);
+		
+		OL_ForecastStatus status = OL_ForecastStatus.PERFECT_FORECAST;
+		String reason = "Forecaster has perfect foresight into heat demand profiles and ambient temperatures.";
 		return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);
 	}
     
@@ -146,15 +172,12 @@ public class J_HeatingManagementProfileHybridHeatPump implements I_HeatingManage
     	return this.gc;
     }
     
-    
-    
 	public void storeStatesAndReset() {
 		//Nothing to store/reset
 	}
 	public void restoreStates() {
 		//Nothing to store/reset
 	}
-	
 	
 	@Override
 	public String toString() {

--- a/_alp/Classes/Class.J_HeatingManagementProfileHybridHeatPump.java
+++ b/_alp/Classes/Class.J_HeatingManagementProfileHybridHeatPump.java
@@ -152,7 +152,7 @@ public class J_HeatingManagementProfileHybridHeatPump implements I_HeatingManage
 			double COP_fr = this.heatPumpAsset.calculateCOP(this.heatPumpAsset.getOutputTemperature_degC(), ambientTemperatureProfile.getValue(t));
 			if (COP_fr < 3.0) {
 				gasLoadProfile_kW[i] = min(gasBurnerMaxOutput_kW, totalHeatDemand_kW / gasBurnerEfficiency_fr);
-				electricityLoadProfile_kW[i] = max(0, (totalHeatDemand_kW - gasBurnerMaxOutput_kW * gasBurnerEfficiency_fr) / COP_fr);
+				electricityLoadProfile_kW[i] = max(0, (totalHeatDemand_kW - gasBurnerMaxOutput_kW) / COP_fr);
 			}
 			else {
 				electricityLoadProfile_kW[i] = min(heatpumpInputCapacity_kW, totalHeatDemand_kW / COP_fr);
@@ -161,7 +161,9 @@ public class J_HeatingManagementProfileHybridHeatPump implements I_HeatingManage
 		}
 		loadMap.put(OL_EnergyCarriers.ELECTRICITY, electricityLoadProfile_kW);
 		loadMap.put(OL_EnergyCarriers.METHANE, gasLoadProfile_kW);
-		
+		Double[] heatLoad = Arrays.stream(fixedHeatDemand_kW).map(d -> -d).boxed().toArray(Double[]::new);
+		loadMap.put(OL_EnergyCarriers.HEAT, heatLoad);
+
 		OL_ForecastStatus status = OL_ForecastStatus.PERFECT_FORECAST;
 		String reason = "Forecaster has perfect foresight into heat demand profiles and ambient temperatures.";
 		return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);

--- a/_alp/Classes/Class.J_HeatingManagementProfileHybridHeatPump.java
+++ b/_alp/Classes/Class.J_HeatingManagementProfileHybridHeatPump.java
@@ -134,8 +134,12 @@ public class J_HeatingManagementProfileHybridHeatPump implements I_HeatingManage
     	return this.heatingPreferences;
     }
     
-    
-    
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);
+	}
     
     //Get parentagent
     public Agent getParentAgent() {

--- a/_alp/Classes/Class.J_HeatingManagementSimple.java
+++ b/_alp/Classes/Class.J_HeatingManagementSimple.java
@@ -239,7 +239,16 @@ public class J_HeatingManagementSimple implements I_HeatingManagement {
 			EC = OL_EnergyCarriers.ELECTRICITY;
 			break;
 		case DISTRICTHEAT:			
-			return new J_AssetTypeForecast(J_HeatingManagementPIcontrol.class, loadMap, OL_ForecastStatus.PERFECT_FORECAST, "GC connected to districtheating, so load is zero.");
+			Double[] heatLoad = Arrays.stream(buildingHeatDemand_kW).boxed().toArray(Double[]::new);
+			loadMap.put(OL_EnergyCarriers.HEAT, heatLoad);
+			if (this.building == null) {
+				String reason = "GC connected to districtheating, so all heat demand is import.";
+				return new J_AssetTypeForecast(J_HeatingManagementPIcontrol.class, loadMap, OL_ForecastStatus.PERFECT_FORECAST, reason);
+			}
+			else {
+				String reason = "GC connected to districtheating, so all heat demand is import. Building forecast simplified by omitting solar radiation & ventilation.";
+				return new J_AssetTypeForecast(J_HeatingManagementPIcontrol.class, loadMap, OL_ForecastStatus.ESTIMATED_FORECAST, reason);
+			}
 		default:
 			throw new RuntimeException(String.format("Tried to forecast J_HeatingManagementPIControl, but encountered an unexepected heating type %s in GC %s", this.gc.f_getCurrentHeatingType(), this.gc.p_gridConnectionID));
 		}
@@ -264,9 +273,9 @@ public class J_HeatingManagementSimple implements I_HeatingManagement {
 			hp = ((J_EAConversionHeatPump)this.heatingAsset);
 			for (int i = 0; i < timeStepsInForecast; i++) {
 				double t = timeOfIntervalStart_h + i * timeParameters.getTimeStep_h();
-				double totalHeatDemand_kW = buildingHeatDemand_kW[i] + otherFixedHeatDemand_kW[i];
+				double heatDemand_kW = buildingHeatDemand_kW[i] + otherFixedHeatDemand_kW[i];
 				double efficiency_fr = hp.calculateCOP(hp.getOutputTemperature_degC(), ambientTemperatureProfile.getValue(t));
-				double load_kW = totalHeatDemand_kW / efficiency_fr;
+				double load_kW = heatDemand_kW / efficiency_fr;
 				loadProfile_kW[i] = load_kW;
 			}
 			break;
@@ -275,12 +284,15 @@ public class J_HeatingManagementSimple implements I_HeatingManagement {
 		if (fixedEfficiency) {
 			for (int i = 0; i < timeStepsInForecast; i++) {
 				double t = timeOfIntervalStart_h + i * timeParameters.getTimeStep_h();
-				double totalHeatDemand_kW = buildingHeatDemand_kW[i] + otherFixedHeatDemand_kW[i];
-				double load_kW = totalHeatDemand_kW / fixedEfficiency_fr;
+				double heatDemand_kW = buildingHeatDemand_kW[i] + otherFixedHeatDemand_kW[i];
+				double load_kW = heatDemand_kW / fixedEfficiency_fr;
 				loadProfile_kW[i] = load_kW;
 			}
 		}
 		loadMap.put(EC, loadProfile_kW);
+		// Building is a flex asset so included in system bounds of heating management, but fixed profiles are not.
+		Double[] heatLoad = Arrays.stream(otherFixedHeatDemand_kW).map(d -> -d).boxed().toArray(Double[]::new);
+		loadMap.put(OL_EnergyCarriers.HEAT, heatLoad);
 		if (this.building == null) {
 			OL_ForecastStatus status = OL_ForecastStatus.PERFECT_FORECAST;
 			String reason = "Forecast is perfect for GridConnections without ThermalBuilding.";

--- a/_alp/Classes/Class.J_HeatingManagementSimple.java
+++ b/_alp/Classes/Class.J_HeatingManagementSimple.java
@@ -216,7 +216,13 @@ public class J_HeatingManagementSimple implements I_HeatingManagement {
     	this.isInitialized = true;
     }
     
-    
+	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
+		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
+		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
+		String reason = "Not yet implemented.";
+		return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);
+	}
+	
     public void notInitialized() {
     	this.isInitialized = false;
     }

--- a/_alp/Classes/Class.J_HeatingManagementSimple.java
+++ b/_alp/Classes/Class.J_HeatingManagementSimple.java
@@ -218,10 +218,114 @@ public class J_HeatingManagementSimple implements I_HeatingManagement {
     
 	public J_AssetTypeForecast getForecast(double timeOfIntervalStart_h, double timeOfIntervalEnd_h) {
 		Map<OL_EnergyCarriers, Double[]> loadMap = new HashMap<>();
-		OL_ForecastStatus status = OL_ForecastStatus.NOT_FORECASTABLE;
-		String reason = "Not yet implemented.";
-		return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);
+		int timeStepsInForecast = roundToInt((timeOfIntervalEnd_h - timeOfIntervalStart_h) / this.timeParameters.getTimeStep_h());
+		Double[] loadProfile_kW = new Double[timeStepsInForecast];
+		J_ProfilePointer ambientTemperatureProfile = this.gc.energyModel.pp_ambientTemperature_degC;
+		J_ProfileForecaster ambientTempeartureForecast = this.gc.energyModel.pf_ambientTemperature_degC;
+		double[] buildingHeatDemand_kW = this.getBuildingHeatDemandProfile(timeOfIntervalStart_h, timeStepsInForecast, ambientTemperatureProfile, ambientTempeartureForecast);
+		double[] otherFixedHeatDemand_kW = this.gc.f_getFixedAssetForecast(timeOfIntervalStart_h, timeOfIntervalEnd_h, OL_EnergyCarriers.HEAT, this.timeParameters);
+		
+		// We switch over the heating type twice, first to set the EnergyCarrier
+		OL_EnergyCarriers EC;
+		switch (this.gc.f_getCurrentHeatingType()) {
+		case GAS_BURNER:
+			EC = OL_EnergyCarriers.METHANE;
+			break;
+		case HYDROGENBURNER:
+			EC = OL_EnergyCarriers.HYDROGEN;
+			break;
+		case LT_DISTRICTHEAT:
+		case ELECTRIC_HEATPUMP:
+			EC = OL_EnergyCarriers.ELECTRICITY;
+			break;
+		case DISTRICTHEAT:			
+			return new J_AssetTypeForecast(J_HeatingManagementPIcontrol.class, loadMap, OL_ForecastStatus.PERFECT_FORECAST, "GC connected to districtheating, so load is zero.");
+		default:
+			throw new RuntimeException(String.format("Tried to forecast J_HeatingManagementPIControl, but encountered an unexepected heating type %s in GC %s", this.gc.f_getCurrentHeatingType(), this.gc.p_gridConnectionID));
+		}
+
+		// Then to determine the profile.
+		// Here we make a distinction between fixed efficiency, and efficiency variable per timestep.
+		boolean fixedEfficiency = false;
+		double fixedEfficiency_fr = 1.0;
+		J_EAConversionHeatPump hp = null;
+		switch (this.gc.f_getCurrentHeatingType()) {
+		case LT_DISTRICTHEAT:
+			fixedEfficiency = true;
+			hp = ((J_EAConversionHeatPump)this.heatingAsset);
+			fixedEfficiency_fr = hp.getCOP();
+			break;
+		case GAS_BURNER:
+		case HYDROGENBURNER:
+			fixedEfficiency = true;
+			fixedEfficiency_fr = this.heatingAsset.getEta_r();
+			break;
+		case ELECTRIC_HEATPUMP:
+			hp = ((J_EAConversionHeatPump)this.heatingAsset);
+			for (int i = 0; i < timeStepsInForecast; i++) {
+				double t = timeOfIntervalStart_h + i * timeParameters.getTimeStep_h();
+				double totalHeatDemand_kW = buildingHeatDemand_kW[i] + otherFixedHeatDemand_kW[i];
+				double efficiency_fr = hp.calculateCOP(hp.getOutputTemperature_degC(), ambientTemperatureProfile.getValue(t));
+				double load_kW = totalHeatDemand_kW / efficiency_fr;
+				loadProfile_kW[i] = load_kW;
+			}
+			break;
+		}
+		
+		if (fixedEfficiency) {
+			for (int i = 0; i < timeStepsInForecast; i++) {
+				double t = timeOfIntervalStart_h + i * timeParameters.getTimeStep_h();
+				double totalHeatDemand_kW = buildingHeatDemand_kW[i] + otherFixedHeatDemand_kW[i];
+				double load_kW = totalHeatDemand_kW / fixedEfficiency_fr;
+				loadProfile_kW[i] = load_kW;
+			}
+		}
+		loadMap.put(EC, loadProfile_kW);
+		if (this.building == null) {
+			OL_ForecastStatus status = OL_ForecastStatus.PERFECT_FORECAST;
+			String reason = "Forecast is perfect for GridConnections without ThermalBuilding.";
+			return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);
+		}
+		else {
+			OL_ForecastStatus status = OL_ForecastStatus.ESTIMATED_FORECAST;
+			String reason = "Temperature & Building states based on current timestep. Building forecast simplified by omitting solar radiation & ventilation.";
+			return new J_AssetTypeForecast(I_HeatingManagement.class, loadMap, status, reason);
+		}
 	}
+	
+	private double[] getBuildingHeatDemandProfile(double timeAtStartForecast_h, int timeStepsInForecast, J_ProfilePointer ambientTemperatureProfile, J_ProfileForecaster ambientTempeartureForecast) {
+        double[] buildingHeatDemandProfile_kW = new double[timeStepsInForecast];
+        if (this.building == null) {
+        	return buildingHeatDemandProfile_kW;
+        }
+        double dayStartTime_h = this.heatingPreferences.getStartOfDayTime_h();
+        double nightStartTime_h = this.heatingPreferences.getStartOfNightTime_h();
+        double daySetpoint_degC = this.heatingPreferences.getDayTimeSetPoint_degC();
+        double nightSetpoint_degC = this.heatingPreferences.getNightTimeSetPoint_degC();
+        double avgTemp24h_degC = ambientTempeartureForecast.getForecast();  // Assumes timeAtStartForecast_h is current model time and forecasting horizon is 24h.
+        double timeStep_h = this.timeParameters.getTimeStep_h();
+
+        double lossFactor_WpK = this.building.getLossFactor_WpK();
+        double lossScalingFactor_fr = this.building.getLossScalingFactor_fr();
+        double heatCapacity_kWhpK = this.building.getHeatCapacity_JpK() / 3.6e6;
+
+        for (int i = 0; i < timeStepsInForecast; i++) {
+            double t = timeAtStartForecast_h + i * timeStep_h;
+            double timeOfDay_h = t % 24.0;
+            double ambientTemp_degC = ambientTemperatureProfile.getValue(t);
+
+            // Same setpoint-selection logic as manageHeating, incl. the heating-season hysteresis
+            double currentSetpoint_degC = daySetpoint_degC;
+            if (avgTemp24h_degC > J_HeatingFunctionLibrary.heatingDaysAvgTempTreshold_degC) {
+                currentSetpoint_degC = nightSetpoint_degC;
+            } else if (timeOfDay_h < dayStartTime_h || timeOfDay_h >= nightStartTime_h) {
+                currentSetpoint_degC = nightSetpoint_degC;
+            }
+            double heatLoss_kW = (lossFactor_WpK * (currentSetpoint_degC - ambientTemp_degC) / 1000) * lossScalingFactor_fr;
+            buildingHeatDemandProfile_kW[i] = max(0, heatLoss_kW);
+        }
+        return buildingHeatDemandProfile_kW;
+    }
 	
     public void notInitialized() {
     	this.isInitialized = false;

--- a/_alp/Classes/Class.J_TimeParameters.java
+++ b/_alp/Classes/Class.J_TimeParameters.java
@@ -108,19 +108,19 @@ public final class J_TimeParameters {
 	//Static methods
 	public static OL_Days getDayFromDayIndex(int dayIndex){
 		switch(dayIndex) {
-		    case 0:
-		        return OL_Days.MONDAY;
 		    case 1:
-		        return OL_Days.TUESDAY;
+		        return OL_Days.MONDAY;
 		    case 2:
-		        return OL_Days.WEDNESDAY;
+		        return OL_Days.TUESDAY;
 		    case 3:
-		        return OL_Days.THURSDAY;
+		        return OL_Days.WEDNESDAY;
 		    case 4:
-		        return OL_Days.FRIDAY;
+		        return OL_Days.THURSDAY;
 		    case 5:
-		        return OL_Days.SATURDAY;
+		        return OL_Days.FRIDAY;
 		    case 6:
+		        return OL_Days.SATURDAY;
+		    case 7:
 		        return OL_Days.SUNDAY;
 		    default:
 		    	throw new RuntimeException("Day found that should not exist.");
@@ -129,19 +129,19 @@ public final class J_TimeParameters {
 	public static int getDayIndexFromDay(OL_Days day){
 		switch(day) {
 		    case MONDAY:
-		        return 0;
-		    case TUESDAY:
 		        return 1;
-		    case WEDNESDAY:
+		    case TUESDAY:
 		        return 2;
-		    case THURSDAY:
+		    case WEDNESDAY:
 		        return 3;
-		    case FRIDAY:
+		    case THURSDAY:
 		        return 4;
-		    case SATURDAY:
+		    case FRIDAY:
 		        return 5;
-		    case SUNDAY:
+		    case SATURDAY:
 		        return 6;
+		    case SUNDAY:
+		        return 7;
 		    default:
 		    	throw new RuntimeException("Day found that should not exist.");
 		}
@@ -156,6 +156,19 @@ public final class J_TimeParameters {
 			    OL_Days.SATURDAY,
 			    OL_Days.SUNDAY
 			);
+	}
+	
+	public int getWeekIndex(double time_h) {
+		double offset = (this.getDayOfWeek1jan() - 1) * 24.0;
+		return (int) Math.floor((time_h + offset) / (7 * 24));
+	}
+	
+	/*
+	 * Note: This method can return a negative time for the first week if 
+	 */
+	public double getWeekStart_h(int weekIndex) {
+		double offset = (this.getDayOfWeek1jan() - 1) * 24.0;
+		return weekIndex * (7 * 24) - offset;
 	}
 	
 	@Override


### PR DESCRIPTION
Accompanied by changes in the Interface-Loader: https://github.com/Zenmo/zero_Interface-Loader/pull/305

- Cleanup of inconsistent indentation in J_ActivityTrackerTrips.
- Added getTripsInRange() to J_ActivityTrackerTrips. This method returns a list of all trips with the starttime in the given range. The returned TripRecords have times relative to the startTime.
- Added the record J_AssetTypeForecast which contains fields to describe a forecast for a certain asset management category.
- Added getForecast(startTime, endTime) to the interface I_AssetManagement. This function must return a AssetTypeForecast. For almost all managements the forecast is (currently) not available for the reason that it is not yet implemented. This is shown in the AssetTypeForecast status & reason.
- Added getForecast implementation for J_ChargingManagementSimple. The forecast is perfect except for the fact that the starting SOC is not known if the forecast starttime is not the current modeltime.